### PR TITLE
fix: dconfig-editor读取没有value值的项时会卡住

### DIFF
--- a/dconfig-center/common/valuehandler.cpp
+++ b/dconfig-center/common/valuehandler.cpp
@@ -56,8 +56,14 @@ public:
 
     QVariant value(const QString &key) const override
     {
-        const auto &v = manager->value(key).value().variant();
-        return decodeQDBusArgument(v);
+        auto reply = manager->value(key);
+        reply.waitForFinished();
+        if (reply.isError()) {
+            qWarning() << "value error key:" << key << ", error message:" << reply.error().message();
+            return QVariant();
+        } else {
+            return decodeQDBusArgument(reply.value().variant());
+        }
     }
 
     void reset(const QString &key) override

--- a/dconfig-center/dde-dconfig-daemon/dconfigconn.cpp
+++ b/dconfig-center/dde-dconfig-daemon/dconfigconn.cpp
@@ -182,8 +182,18 @@ QDBusVariant DSGConfigConn::value(const QString &key)
     if (!contains(key))
         return QDBusVariant();
 
-    qCDebug(cfLog) << "get value key:" << key << ", value:" << m_config->value(key, m_cache);
-    return QDBusVariant{m_config->value(key, m_cache)};
+    const auto &value = m_config->value(key, m_cache);
+    if (value.isNull()) {
+        QString errorMsg = QString("[%1] requires the value in [%2].").arg(key).arg(getAppid());
+        qWarning() << errorMsg;
+        if (calledFromDBus()) {
+            sendErrorReply(QDBusError::Failed, errorMsg);
+        }
+        return QDBusVariant();
+    }
+
+    qCDebug(cfLog) << "get value key:" << key << ", value:" << value;
+    return QDBusVariant{value};
 }
 
 /*!

--- a/dconfig-center/dde-dconfig-editor/CMakeLists.txt
+++ b/dconfig-center/dde-dconfig-editor/CMakeLists.txt
@@ -41,7 +41,9 @@ set(SOURCES
     oemdialog.cpp
 )
 
-ADD_EXECUTABLE(dde-dconfig-editor ${HEADERS} ${SOURCES} ${DCONFIG_DBUS_XML})
+set(QRC dde-dconfig-editor.qrc)
+
+ADD_EXECUTABLE(dde-dconfig-editor ${HEADERS} ${SOURCES} ${QRC} ${DCONFIG_DBUS_XML})
 
 set(COMMON_LIBS
     Qt5::Core

--- a/dconfig-center/dde-dconfig-editor/appicon/dde-dconfig-editor.svg
+++ b/dconfig-center/dde-dconfig-editor/appicon/dde-dconfig-editor.svg
@@ -1,0 +1,158 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="32px" height="32px" viewBox="0 0 32 32" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>dde-dconfig-editor/32px</title>
+    <defs>
+        <filter x="-17.9%" y="-15.1%" width="132.1%" height="129.4%" filterUnits="objectBoundingBox" id="filter-1">
+            <feOffset dx="0" dy="1" in="SourceAlpha" result="shadowOffsetOuter1"></feOffset>
+            <feGaussianBlur stdDeviation="0.5" in="shadowOffsetOuter1" result="shadowBlurOuter1"></feGaussianBlur>
+            <feColorMatrix values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0  0 0 0 0.15 0" type="matrix" in="shadowBlurOuter1" result="shadowMatrixOuter1"></feColorMatrix>
+            <feMerge>
+                <feMergeNode in="shadowMatrixOuter1"></feMergeNode>
+                <feMergeNode in="SourceGraphic"></feMergeNode>
+            </feMerge>
+        </filter>
+        <linearGradient x1="48.6615875%" y1="50%" x2="50.9760059%" y2="93.9895149%" id="linearGradient-2">
+            <stop stop-color="#B3C9DC" offset="0%"></stop>
+            <stop stop-color="#A8C0D5" offset="78.2560913%"></stop>
+            <stop stop-color="#8FA5B8" offset="100%"></stop>
+        </linearGradient>
+        <path d="M23.1441845,5.14352958 L25.3918218,5.14352958 C25.7485608,5.14352958 26.0377549,5.43272365 26.0377549,5.78946261 L26.0377549,25.0075544 C26.0377549,25.9849613 25.24541,26.7773061 24.2680032,26.7773061 C23.2905963,26.7773061 22.4982515,25.9849613 22.4982515,25.0075544 L22.4982515,5.78946261 C22.4982515,5.43272365 22.7874455,5.14352958 23.1441845,5.14352958 Z" id="path-3"></path>
+        <filter x="-42.4%" y="-6.9%" width="184.8%" height="113.9%" filterUnits="objectBoundingBox" id="filter-4">
+            <feGaussianBlur stdDeviation="1" in="SourceAlpha" result="shadowBlurInner1"></feGaussianBlur>
+            <feOffset dx="-1" dy="-1" in="shadowBlurInner1" result="shadowOffsetInner1"></feOffset>
+            <feComposite in="shadowOffsetInner1" in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1" result="shadowInnerInner1"></feComposite>
+            <feColorMatrix values="0 0 0 0 0.431591628   0 0 0 0 0.553893642   0 0 0 0 0.645620153  0 0 0 1 0" type="matrix" in="shadowInnerInner1"></feColorMatrix>
+        </filter>
+        <linearGradient x1="66.5613453%" y1="3.54981095%" x2="56.0173192%" y2="101.69108%" id="linearGradient-5">
+            <stop stop-color="#3DC4FF" offset="0%"></stop>
+            <stop stop-color="#4762FF" offset="100%"></stop>
+        </linearGradient>
+        <linearGradient x1="50%" y1="0%" x2="53.7269412%" y2="97.8183741%" id="linearGradient-6">
+            <stop stop-color="#48FFD0" offset="0%"></stop>
+            <stop stop-color="#00B7FF" offset="100%"></stop>
+        </linearGradient>
+        <path d="M1.875,0 L21.125,0 C22.1605339,-1.90224492e-16 23,0.839466094 23,1.875 L23,21.125 C23,22.1605339 22.1605339,23 21.125,23 L1.875,23 C0.839466094,23 1.26816328e-16,22.1605339 0,21.125 L0,1.875 C-1.26816328e-16,0.839466094 0.839466094,1.90224492e-16 1.875,0 Z" id="path-7"></path>
+        <filter x="-15.2%" y="-10.9%" width="130.4%" height="130.4%" filterUnits="objectBoundingBox" id="filter-8">
+            <feOffset dx="0" dy="1" in="SourceAlpha" result="shadowOffsetOuter1"></feOffset>
+            <feGaussianBlur stdDeviation="1" in="shadowOffsetOuter1" result="shadowBlurOuter1"></feGaussianBlur>
+            <feColorMatrix values="0 0 0 0 0.0715196752   0 0 0 0 0.236045063   0 0 0 0 0.181359068  0 0 0 0.15 0" type="matrix" in="shadowBlurOuter1"></feColorMatrix>
+        </filter>
+        <linearGradient x1="50%" y1="0.522592905%" x2="50%" y2="99.474887%" id="linearGradient-9">
+            <stop stop-color="#FFFFFF" stop-opacity="0.8" offset="0%"></stop>
+            <stop stop-color="#FFFFFF" stop-opacity="0.531304633" offset="100%"></stop>
+        </linearGradient>
+        <linearGradient x1="50.2459595%" y1="4.99601278%" x2="50.2459595%" y2="100%" id="linearGradient-10">
+            <stop stop-color="#E4F6FB" offset="0%"></stop>
+            <stop stop-color="#BBCDDD" offset="92.7062301%"></stop>
+            <stop stop-color="#91A7BB" offset="100%"></stop>
+        </linearGradient>
+        <rect id="path-11" x="0" y="1" width="17" height="3" rx="1.125"></rect>
+        <filter x="-2.9%" y="-16.7%" width="105.9%" height="133.3%" filterUnits="objectBoundingBox" id="filter-12">
+            <feOffset dx="0" dy="1" in="SourceAlpha" result="shadowOffsetInner1"></feOffset>
+            <feComposite in="shadowOffsetInner1" in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1" result="shadowInnerInner1"></feComposite>
+            <feColorMatrix values="0 0 0 0 0.490255934   0 0 0 0 0.604394171   0 0 0 0 0.697780001  0 0 0 1 0" type="matrix" in="shadowInnerInner1" result="shadowMatrixInner1"></feColorMatrix>
+            <feOffset dx="0" dy="-1" in="SourceAlpha" result="shadowOffsetInner2"></feOffset>
+            <feComposite in="shadowOffsetInner2" in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1" result="shadowInnerInner2"></feComposite>
+            <feColorMatrix values="0 0 0 0 0.918410585   0 0 0 0 0.968417001   0 0 0 0 1  0 0 0 1 0" type="matrix" in="shadowInnerInner2" result="shadowMatrixInner2"></feColorMatrix>
+            <feMerge>
+                <feMergeNode in="shadowMatrixInner1"></feMergeNode>
+                <feMergeNode in="shadowMatrixInner2"></feMergeNode>
+            </feMerge>
+        </filter>
+        <linearGradient x1="50%" y1="5.74152685%" x2="50%" y2="92.3400923%" id="linearGradient-13">
+            <stop stop-color="#C6D8E7" offset="0%"></stop>
+            <stop stop-color="#E4F3FF" offset="100%"></stop>
+        </linearGradient>
+        <rect id="path-14" x="3" y="0" width="4" height="5" rx="2"></rect>
+        <filter x="-50.0%" y="-20.0%" width="200.0%" height="180.0%" filterUnits="objectBoundingBox" id="filter-15">
+            <feOffset dx="0" dy="1" in="SourceAlpha" result="shadowOffsetOuter1"></feOffset>
+            <feGaussianBlur stdDeviation="0.5" in="shadowOffsetOuter1" result="shadowBlurOuter1"></feGaussianBlur>
+            <feColorMatrix values="0 0 0 0 0.529411765   0 0 0 0 0.635294118   0 0 0 0 0.721568627  0 0 0 0.806930862 0" type="matrix" in="shadowBlurOuter1"></feColorMatrix>
+        </filter>
+        <filter x="-37.5%" y="-10.0%" width="175.0%" height="160.0%" filterUnits="objectBoundingBox" id="filter-16">
+            <feOffset dx="0" dy="-1" in="SourceAlpha" result="shadowOffsetInner1"></feOffset>
+            <feComposite in="shadowOffsetInner1" in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1" result="shadowInnerInner1"></feComposite>
+            <feColorMatrix values="0 0 0 0 0.724855946   0 0 0 0 0.815765542   0 0 0 0 0.895311439  0 0 0 1 0" type="matrix" in="shadowInnerInner1" result="shadowMatrixInner1"></feColorMatrix>
+            <feOffset dx="0" dy="1" in="SourceAlpha" result="shadowOffsetInner2"></feOffset>
+            <feComposite in="shadowOffsetInner2" in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1" result="shadowInnerInner2"></feComposite>
+            <feColorMatrix values="0 0 0 0 1   0 0 0 0 1   0 0 0 0 1  0 0 0 0.587607217 0" type="matrix" in="shadowInnerInner2" result="shadowMatrixInner2"></feColorMatrix>
+            <feMerge>
+                <feMergeNode in="shadowMatrixInner1"></feMergeNode>
+                <feMergeNode in="shadowMatrixInner2"></feMergeNode>
+            </feMerge>
+        </filter>
+        <rect id="path-17" x="0" y="1" width="17" height="3" rx="1.125"></rect>
+        <filter x="-2.9%" y="-16.7%" width="105.9%" height="133.3%" filterUnits="objectBoundingBox" id="filter-18">
+            <feOffset dx="0" dy="1" in="SourceAlpha" result="shadowOffsetInner1"></feOffset>
+            <feComposite in="shadowOffsetInner1" in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1" result="shadowInnerInner1"></feComposite>
+            <feColorMatrix values="0 0 0 0 0.490255934   0 0 0 0 0.604394171   0 0 0 0 0.697780001  0 0 0 1 0" type="matrix" in="shadowInnerInner1" result="shadowMatrixInner1"></feColorMatrix>
+            <feOffset dx="0" dy="-1" in="SourceAlpha" result="shadowOffsetInner2"></feOffset>
+            <feComposite in="shadowOffsetInner2" in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1" result="shadowInnerInner2"></feComposite>
+            <feColorMatrix values="0 0 0 0 0.918410585   0 0 0 0 0.968417001   0 0 0 0 1  0 0 0 1 0" type="matrix" in="shadowInnerInner2" result="shadowMatrixInner2"></feColorMatrix>
+            <feMerge>
+                <feMergeNode in="shadowMatrixInner1"></feMergeNode>
+                <feMergeNode in="shadowMatrixInner2"></feMergeNode>
+            </feMerge>
+        </filter>
+        <rect id="path-19" x="10" y="0" width="4" height="5" rx="2"></rect>
+        <filter x="-50.0%" y="-20.0%" width="200.0%" height="180.0%" filterUnits="objectBoundingBox" id="filter-20">
+            <feOffset dx="0" dy="1" in="SourceAlpha" result="shadowOffsetOuter1"></feOffset>
+            <feGaussianBlur stdDeviation="0.5" in="shadowOffsetOuter1" result="shadowBlurOuter1"></feGaussianBlur>
+            <feColorMatrix values="0 0 0 0 0.529411765   0 0 0 0 0.635294118   0 0 0 0 0.721568627  0 0 0 0.806930862 0" type="matrix" in="shadowBlurOuter1"></feColorMatrix>
+        </filter>
+        <filter x="-37.5%" y="-10.0%" width="175.0%" height="160.0%" filterUnits="objectBoundingBox" id="filter-21">
+            <feOffset dx="0" dy="-1" in="SourceAlpha" result="shadowOffsetInner1"></feOffset>
+            <feComposite in="shadowOffsetInner1" in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1" result="shadowInnerInner1"></feComposite>
+            <feColorMatrix values="0 0 0 0 0.724855946   0 0 0 0 0.815765542   0 0 0 0 0.895311439  0 0 0 1 0" type="matrix" in="shadowInnerInner1" result="shadowMatrixInner1"></feColorMatrix>
+            <feOffset dx="0" dy="1" in="SourceAlpha" result="shadowOffsetInner2"></feOffset>
+            <feComposite in="shadowOffsetInner2" in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1" result="shadowInnerInner2"></feComposite>
+            <feColorMatrix values="0 0 0 0 1   0 0 0 0 1   0 0 0 0 1  0 0 0 0.587607217 0" type="matrix" in="shadowInnerInner2" result="shadowMatrixInner2"></feColorMatrix>
+            <feMerge>
+                <feMergeNode in="shadowMatrixInner1"></feMergeNode>
+                <feMergeNode in="shadowMatrixInner2"></feMergeNode>
+            </feMerge>
+        </filter>
+    </defs>
+    <g id="dde-dconfig-editor/32px" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="编组" filter="url(#filter-1)" transform="translate(2.000000, 2.189252)">
+            <g id="矩形">
+                <use fill="url(#linearGradient-2)" fill-rule="evenodd" xlink:href="#path-3"></use>
+                <use fill="black" fill-opacity="1" filter="url(#filter-4)" xlink:href="#path-3"></use>
+            </g>
+            <g id="编组-3" transform="translate(3.160271, 0.000000)" fill="url(#linearGradient-5)" fill-rule="nonzero">
+                <path d="M4.69958384,0.0140200658 L22.5799397,1.89235069 C23.9659114,2.03794695 24.9713733,3.27894781 24.8257018,4.6642037 L22.9134305,22.8488543 C22.767759,24.2341101 21.5261169,25.2390528 20.1401453,25.0934566 L2.25978938,23.2151259 C0.873817749,23.0695297 -0.131644179,21.8285288 0.0140273098,20.4432729 L1.92629864,2.25862238 C2.07197013,0.873366491 3.3136122,-0.131576195 4.69958384,0.0140200658 Z" id="矩形"></path>
+            </g>
+            <g id="编组-4" transform="translate(1.000000, 0.810748)">
+                <g id="矩形">
+                    <use fill="black" fill-opacity="1" filter="url(#filter-8)" xlink:href="#path-7"></use>
+                    <use fill="url(#linearGradient-6)" fill-rule="evenodd" xlink:href="#path-7"></use>
+                </g>
+                <path d="M3.5,3 L5.5,3 C5.77614237,3 6,3.22385763 6,3.5 C6,3.77614237 5.77614237,4 5.5,4 L3.5,4 C3.22385763,4 3,3.77614237 3,3.5 C3,3.22385763 3.22385763,3 3.5,3 Z M8.5,3 L12.5,3 C12.7761424,3 13,3.22385763 13,3.5 C13,3.77614237 12.7761424,4 12.5,4 L8.5,4 C8.22385763,4 8,3.77614237 8,3.5 C8,3.22385763 8.22385763,3 8.5,3 Z M15.5,3 L19.5,3 C19.7761424,3 20,3.22385763 20,3.5 C20,3.77614237 19.7761424,4 19.5,4 L15.5,4 C15.2238576,4 15,3.77614237 15,3.5 C15,3.22385763 15.2238576,3 15.5,3 Z M3.5,6 L5,6 C5.27614237,6 5.5,6.22385763 5.5,6.5 C5.5,6.77614237 5.27614237,7 5,7 L3.5,7 C3.22385763,7 3,6.77614237 3,6.5 C3,6.22385763 3.22385763,6 3.5,6 Z M12,5 L14,5 C14.2761424,5 14.5,5.22385763 14.5,5.5 C14.5,5.77614237 14.2761424,6 14,6 L12,6 C11.7238576,6 11.5,5.77614237 11.5,5.5 C11.5,5.22385763 11.7238576,5 12,5 Z M17.5,5 L19.5,5 C19.7761424,5 20,5.22385763 20,5.5 C20,5.77614237 19.7761424,6 19.5,6 L17.5,6 C17.2238576,6 17,5.77614237 17,5.5 C17,5.22385763 17.2238576,5 17.5,5 Z" id="形状结合" fill="url(#linearGradient-9)" opacity="0.598195394"></path>
+            </g>
+            <path d="M1.93779902,5.81074766 L11.1973374,5.81074766 C11.7112736,5.81074766 12.2041604,6.01490805 12.5675682,6.37831586 L13.4324318,7.24317947 C13.7958396,7.60658728 14.2887264,7.81074766 14.8026626,7.81074766 L20,7.81074766 C21.6568542,7.81074766 23,9.15389341 23,10.8107477 L23,10.8107477 L23,10.8107477 L0,10.8107477 L0,7.74854669 C-1.31063764e-16,6.67832984 0.867582175,5.81074766 1.93779902,5.81074766 Z" id="形状结合" fill="#F3FCFF"></path>
+            <path d="M11.0311005,6.81074766 C11.6410369,6.81074766 12.2153779,7.09791815 12.5813397,7.58586725 L12.9186603,8.03562807 C13.2846221,8.52357718 13.8589631,8.81074766 14.4688995,8.81074766 L21,8.81074766 C22.0543618,8.81074766 22.9181651,9.62662545 22.9945143,10.6614853 L23,10.8107477 L23,24.3107477 C23,25.1391748 23.6715729,25.8107477 24.5,25.8107477 C25.3284271,25.8107477 26,25.1391748 26,24.3107477 L26,24.3107477 L25.9999049,23.3135354 C26.0019079,23.2915893 26.0040027,23.2700882 26.0061893,23.2490321 C26.0368017,22.954246 26.3680719,19.8634249 27,13.9765687 L27,24.5810824 C27,26.3647773 25.5540296,27.8107477 23.7703347,27.8107477 L3.22966528,27.8107477 C1.4459704,27.8107477 -6.69738797e-16,26.3647773 0,24.5810824 L0,8.74854664 C9.09808442e-17,7.67832982 0.867582154,6.81074766 1.93779898,6.81074766 L11.0311005,6.81074766 Z" id="形状结合" fill="url(#linearGradient-10)"></path>
+            <g id="编组-2" transform="translate(3.000000, 11.810748)">
+                <g id="矩形">
+                    <use fill="#A0BBD1" fill-rule="evenodd" xlink:href="#path-11"></use>
+                    <use fill="black" fill-opacity="1" filter="url(#filter-12)" xlink:href="#path-11"></use>
+                </g>
+                <g id="矩形">
+                    <use fill="black" fill-opacity="1" filter="url(#filter-15)" xlink:href="#path-14"></use>
+                    <use fill="url(#linearGradient-13)" fill-rule="evenodd" xlink:href="#path-14"></use>
+                    <use fill="black" fill-opacity="1" filter="url(#filter-16)" xlink:href="#path-14"></use>
+                </g>
+            </g>
+            <g id="编组-2" transform="translate(3.000000, 18.810748)">
+                <g id="矩形">
+                    <use fill="#A0BBD1" fill-rule="evenodd" xlink:href="#path-17"></use>
+                    <use fill="black" fill-opacity="1" filter="url(#filter-18)" xlink:href="#path-17"></use>
+                </g>
+                <g id="矩形">
+                    <use fill="black" fill-opacity="1" filter="url(#filter-20)" xlink:href="#path-19"></use>
+                    <use fill="url(#linearGradient-13)" fill-rule="evenodd" xlink:href="#path-19"></use>
+                    <use fill="black" fill-opacity="1" filter="url(#filter-21)" xlink:href="#path-19"></use>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/dconfig-center/dde-dconfig-editor/dde-dconfig-editor.qrc
+++ b/dconfig-center/dde-dconfig-editor/dde-dconfig-editor.qrc
@@ -1,0 +1,5 @@
+<RCC>
+    <qresource prefix="/">
+        <file>appicon/dde-dconfig-editor.svg</file>
+    </qresource>
+</RCC>

--- a/dconfig-center/dde-dconfig-editor/main.cpp
+++ b/dconfig-center/dde-dconfig-editor/main.cpp
@@ -26,10 +26,15 @@
 
 DWIDGET_USE_NAMESPACE
 
+
 int main(int argc, char *argv[])
 {
     DApplication a(argc, argv);
     a.setApplicationVersion("1.0.0");
+    a.setApplicationName("dde-dconfig-editor");
+    a.setOrganizationName("deepin");
+    a.setProductIcon(QIcon::fromTheme(APP_ICON));
+    a.setWindowIcon(QIcon::fromTheme(APP_ICON));
 
     MainWindow window;
     window.show();

--- a/dconfig-center/dde-dconfig-editor/mainwindow.cpp
+++ b/dconfig-center/dde-dconfig-editor/mainwindow.cpp
@@ -166,6 +166,7 @@ MainWindow::MainWindow(QWidget *parent) :
 
     // set history
     DTitlebar *titlebar = this->titlebar();
+    titlebar->setIcon(QIcon(APP_ICON));
     connect(titlebar->menu()->addAction("setting history"), &QAction::triggered, [this](){
         qInfo() << "show history view";
         historyView->show();

--- a/dconfig-center/dde-dconfig-editor/mainwindow.h
+++ b/dconfig-center/dde-dconfig-editor/mainwindow.h
@@ -34,6 +34,8 @@ class ExportDialog;
 class OEMDialog;
 DWIDGET_USE_NAMESPACE
 
+#define APP_ICON "://appicon/dde-dconfig-editor.svg"
+
 class LevelDelegate : public DStyledItemDelegate {
     Q_OBJECT
 public:


### PR DESCRIPTION
读取value时，判断value值是否为空；
如果value值为空，发送错误，返回默认值。

Log: 修复dconfig-editor读取没有value值的项时会卡住
Bug: https://pms.uniontech.com/bug-view-144233.html
Influence: dde-dconfig-editor读取没有value值的项
Change-Id: Iec8f00e587bbad28f661d4c26b1ddbb20a183676