### PR TITLE
chore: use GNUInstallDirs in CmakeLists

### DIFF
--- a/dconfig-center/CMakeLists.txt
+++ b/dconfig-center/CMakeLists.txt
@@ -8,6 +8,7 @@ project(dconfig-center)
 
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
+include(GNUInstallDirs)
 
 add_subdirectory("dde-dconfig-daemon")
 add_subdirectory("dde-dconfig-editor")

--- a/dconfig-center/dde-dconfig-daemon/CMakeLists.txt
+++ b/dconfig-center/dde-dconfig-daemon/CMakeLists.txt
@@ -39,13 +39,13 @@ set(DCONFIG_XMLS_FILES
     services/org.desktopspec.ConfigManager.xml
     services/org.desktopspec.ConfigManager.Manager.xml
 )
-install (FILES ${DCONFIG_XMLS_FILES} DESTINATION share/dbus-1/interfaces)
+install (FILES ${DCONFIG_XMLS_FILES} DESTINATION ${CMAKE_INSTALL_DATADIR}/dbus-1/interfaces)
 
 ## dbus config file
-install (FILES services/org.desktopspec.ConfigManager.conf DESTINATION /usr/share/dbus-1/system.d)
+install (FILES services/org.desktopspec.ConfigManager.conf DESTINATION ${CMAKE_INSTALL_DATADIR}/dbus-1/system.d)
 
 ## services files
-install(FILES services/org.desktopspec.ConfigManager.service DESTINATION /usr/share/dbus-1/system-services)
+install(FILES services/org.desktopspec.ConfigManager.service DESTINATION ${CMAKE_INSTALL_DATADIR}/dbus-1/system-services)
 
 ## bin
-install(TARGETS dde-dconfig-daemon DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
+install(TARGETS dde-dconfig-daemon DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/dconfig-center/dde-dconfig-editor/CMakeLists.txt
+++ b/dconfig-center/dde-dconfig-editor/CMakeLists.txt
@@ -66,4 +66,4 @@ target_include_directories(${PROJECT_NAME} PUBLIC
     ../common
 )
 
-install(TARGETS dde-dconfig-editor DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
+install(TARGETS dde-dconfig-editor DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/dconfig-center/dde-dconfig/CMakeLists.txt
+++ b/dconfig-center/dde-dconfig/CMakeLists.txt
@@ -52,7 +52,7 @@ target_include_directories(${PROJECT_NAME} PUBLIC
     ../common
 )
 
-install(TARGETS dde-dconfig DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
+install(TARGETS dde-dconfig DESTINATION ${CMAKE_INSTALL_BINDIR})
 
-set(BASH_COMPLETION_COMPLETIONSDIR "/usr/share/bash-completion/completions/")
+set(BASH_COMPLETION_COMPLETIONSDIR ${CMAKE_INSTALL_DATADIR}/bash-completion/completions/)
 install(DIRECTORY bash_completion.d/ DESTINATION ${BASH_COMPLETION_COMPLETIONSDIR})


### PR DESCRIPTION
Log: use GNUInstallDirs in CmakeLists

relate:https://github.com/linuxdeepin/developer-center/issues/3167