### PR TITLE
chore: rules文件格式错误

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -7,4 +7,4 @@ export QT_SELECT = qt5
 	dh $@ --parallel
 
 override_dh_auto_configure:
-        dh_auto_configure -- -DDVERSION=$(DEB_VERSION_UPSTREAM)
+	dh_auto_configure -- -DDVERSION=$(DEB_VERSION_UPSTREAM)


### PR DESCRIPTION
空格改成Tab

Log:
Influence: deb package
Change-Id: I5965c1c8e165ff78adaeb617efef8e78fd73e630