### PR TITLE
feat: Add sync2file when setValue

### DIFF
--- a/dconfig-center/dde-dconfig-daemon/dconfig_global.h
+++ b/dconfig-center/dde-dconfig-daemon/dconfig_global.h
@@ -18,6 +18,7 @@ using ConnKey = QString;
 using ResourceKey = QString;
 using ConnServiceName = QString;
 using ConnRefCount = int;
+using ConfigCacheKey = QString;
 
 inline QString getResourceKey(const ConnKey &connKey)
 {

--- a/dconfig-center/dde-dconfig-daemon/dconfigrefmanager.h
+++ b/dconfig-center/dde-dconfig-daemon/dconfigrefmanager.h
@@ -68,3 +68,47 @@ private:
     QMap<ConnKey, QTimer*> m_delayReleaseingConns;
     ObjectPool<QTimer> m_timerPool;
 };
+
+struct ConfigSyncBatchRequest
+{
+    QList<ConfigCacheKey> data;
+};
+
+class ConfigSyncRequestCache : public QObject
+{
+    Q_OBJECT
+public:
+    explicit ConfigSyncRequestCache(QObject *parent = nullptr);
+    virtual ~ConfigSyncRequestCache() override;
+
+    void pushRequest(const ConfigCacheKey& key);
+
+    static ConfigCacheKey globalKey(const ResourceKey &key);
+    static ConfigCacheKey userKey(const ConnKey &key);
+    static bool isGlobalKey(const ConfigCacheKey &key);
+    static bool isUserKey(const ConfigCacheKey &key);
+    static ResourceKey getGlobalKey(const ConfigCacheKey &key);
+    static ConnKey getUserKey(const ConfigCacheKey &key);
+
+    int requestsCount() const;
+    int delaySyncTime() const;
+    void setDelaySyncTime(const int time);
+    int batchCount() const;
+    void setBatchCount(const int count);
+
+Q_SIGNALS:
+    void syncConfigRequest(const ConfigSyncBatchRequest &request);
+
+protected:
+    virtual void timerEvent(QTimerEvent *event) override;
+
+private:
+    void customRequest();
+
+    QBasicTimer *m_syncTimer = nullptr;
+    QSet<ConfigCacheKey> m_configCacheKeys;
+    int m_delaySyncTime;
+    int m_batchCount;
+};
+
+Q_DECLARE_METATYPE(ConfigSyncBatchRequest)

--- a/dconfig-center/dde-dconfig-daemon/dconfigresource.h
+++ b/dconfig-center/dde-dconfig-daemon/dconfigresource.h
@@ -18,6 +18,7 @@ DCORE_END_NAMESPACE
 
 DCORE_USE_NAMESPACE
 class DSGConfigConn;
+class ConfigSyncRequestCache;
 /**
  * @brief The DSGConfigResource class
  * 管理单个链接
@@ -32,6 +33,8 @@ public:
     virtual ~DSGConfigResource() override;
 
     bool load(const QString &appid, const QString &name, const QString &subpath);
+
+    void setSyncRequestCache(ConfigSyncRequestCache *cache);
 
     DSGConfigConn* connObject(const uint uid);
 
@@ -49,6 +52,7 @@ public:
 
     void save();
 
+    void doSyncConfigCache(const ConfigCacheKey &key);
 Q_SIGNALS: // SIGNALS
     void updateValueChanged(const QString &key);
 
@@ -65,6 +69,9 @@ public Q_SLOTS: // METHODS
 
     void onReleaseChanged(const ConnServiceName &service);
 
+private Q_SLOTS:
+    void onValueChanged(const QString &key);
+
 private:
     QString getConnKey(const uint uid) const;
 
@@ -77,5 +84,6 @@ private:
     QString m_appid;
     QString m_fileName;
     QString m_subpath;
+    ConfigSyncRequestCache *m_syncRequestCache = nullptr;
 };
 

--- a/dconfig-center/dde-dconfig-daemon/dconfigserver.h
+++ b/dconfig-center/dde-dconfig-daemon/dconfigserver.h
@@ -12,6 +12,8 @@
 
 class DSGConfigResource;
 class RefManager;
+class ConfigSyncBatchRequest;
+class ConfigSyncRequestCache;
 /**
  * @brief The DSGConfigServer class
  * 管理配置策略服务
@@ -63,7 +65,10 @@ private Q_SLOTS:
 
     void onTryExit();
 
+    void doSyncConfigCache(const ConfigSyncBatchRequest &request);
+
 private:
+    ResourceKey getResourceKeyByConfigCache(const ConfigCacheKey &key);
 
     ConfigureId getConfigureIdByPath(const QString &path);
 
@@ -80,4 +85,5 @@ private:
 
     QString m_localPrefix;
     bool m_enableExit = false;
+    ConfigSyncRequestCache *m_syncRequestCache = nullptr;
 };


### PR DESCRIPTION
  It's to reduce the risk caused by abnormality.
  We start a sync request when every connection call setValue(),
and lay sync time is 30s, batch max count is 10 for when sync.
  TODO We can use queue or other scheduling mechanism if necessary.

Log: 将缓存定期同步到文件中，减少因异常丢失数据风险
Influence: cache文件由之前连接关闭同步 改为 延时30s同步
Change-Id: Ib1eb387b181d2aca6588f899c5538f134123a61b