### PR TITLE
fix: path parse error of meta file

### DIFF
--- a/dconfig-center/dde-dconfig-daemon/dconfig_global.h
+++ b/dconfig-center/dde-dconfig-daemon/dconfig_global.h
@@ -51,7 +51,7 @@ inline ConfigureId getMetaConfigureId(const QString &path)
 {
     ConfigureId info;
     // /usr/share/dsg/configs/[$appid]/[$subpath]/$resource.json
-    static QRegularExpression usrReg(R"(^/usr/share/dsg/configs/(?<appid>([a-z0-9\s\-_\@\-\^!#$%&]+\/)?)(?<subpath>([a-z0-9\s\-_\@\-\^!#$%&]+\/)*)(?<resource>[a-z0-9\s\-_\@\-\^!#$%&]+).json$)");
+    static QRegularExpression usrReg(R"(^/usr/share/dsg/configs/(?<appid>([a-z0-9\s\-_\@\-\^!#$%&.]+\/)?)(?<subpath>([a-z0-9\s\-_\@\-\^!#$%&.]+\/)*)(?<resource>[a-z0-9\s\-_\@\-\^!#$%&.]+).json$)");
 
     QRegularExpressionMatch match;
     match = usrReg.match(path);
@@ -69,10 +69,10 @@ inline ConfigureId getOverrideConfigureId(const QString &path)
 {
     ConfigureId info;
     // /usr/share/dsg/configs/overrides/[$appid]/$resource/[$subpath]/$override_id.json
-    static QRegularExpression usrReg(R"(^/usr/share/dsg/configs/overrides/(?<appid>([a-z0-9\s\-_\@\-\^!#$%&]+\/)?)(?<resource>[a-z0-9\s\-_\@\-\^!#$%&]+)/(?<subpath>([a-z0-9\s\-_\@\-\^!#$%&]+\/)*)(?<configurationid>[a-z0-9\s\-_\@\-\^!#$%&]+).json$)");
+    static QRegularExpression usrReg(R"(^/usr/share/dsg/configs/overrides/(?<appid>([a-z0-9\s\-_\@\-\^!#$%&.]+\/)?)(?<resource>[a-z0-9\s\-_\@\-\^!#$%&.]+)/(?<subpath>([a-z0-9\s\-_\@\-\^!#$%&.]+\/)*)(?<configurationid>[a-z0-9\s\-_\@\-\^!#$%&.]+).json$)");
 
     // /etc/dsg/configs/overrides/[$appid]/$resource/[$subpath]/$override_id.json
-    static QRegularExpression etcReg(R"(^/etc/dsg/configs/overrides/(?<appid>([a-z0-9\s\-_\@\-\^!#$%&]+\/)?)(?<resource>[a-z0-9\s\-_\@\-\^!#$%&]+)/(?<subpath>([a-z0-9\s\-_\@\-\^!#$%&]+\/)*)(?<configurationid>[a-z0-9\s\-_\@\-\^!#$%&]+).json$)");
+    static QRegularExpression etcReg(R"(^/etc/dsg/configs/overrides/(?<appid>([a-z0-9\s\-_\@\-\^!#$%&.]+\/)?)(?<resource>[a-z0-9\s\-_\@\-\^!#$%&.]+)/(?<subpath>([a-z0-9\s\-_\@\-\^!#$%&.]+\/)*)(?<configurationid>[a-z0-9\s\-_\@\-\^!#$%&.]+).json$)");
 
     QRegularExpressionMatch match;
     match = usrReg.match(path);

--- a/dconfig-center/tests/ut_dconfigserver.cpp
+++ b/dconfig-center/tests/ut_dconfigserver.cpp
@@ -135,6 +135,7 @@ TEST_F(ut_DConfigServer, setDelayReleaseTime) {
 TEST_F(ut_DConfigServer, metaPathToConfigureId) {
     QStringList appPaths {
         "/usr/share/dsg/configs/example.json",
+        "/usr/share/dsg/configs/dconfig-example_abc.d/example.json",
         "/usr/share/dsg/configs/dconfig-example/example.json",
         "/usr/share/dsg/configs/dconfig-example/a/b/example.json"
     };
@@ -149,6 +150,7 @@ TEST_F(ut_DConfigServer, overridePathToConfigureId) {
     QStringList paths {
         "/usr/share/dsg/configs/overrides/example/a.json",
         "/usr/share/dsg/configs/overrides/dconfig-example/example/a.json",
+        "/usr/share/dsg/configs/overrides/dconfig-example_abc.d/example/a.json",
         "/usr/share/dsg/configs/overrides/dconfig-example/example/a/b/a.json",
         "/etc/dsg/configs/overrides/example/a.json",
         "/etc/dsg/configs/overrides/dconfig-example/example/a.json",


### PR DESCRIPTION
  RegularExpression can't parse meta file that path contains '.'

Log: 配置中心服务调用sync接口路径解析错误
Influence: none
Change-Id: Id544b5e7518a5f399feca108a25989b0b9216852