### PR TITLE
feat: Empty Appid as app-resource value's fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-CMakeLists.txt.user
+CMakeLists.txt.user*
+build*/

--- a/dconfig-center/dde-dconfig-daemon/dconfig_global.h
+++ b/dconfig-center/dde-dconfig-daemon/dconfig_global.h
@@ -14,19 +14,47 @@
 
 Q_DECLARE_LOGGING_CATEGORY(cfLog);
 
+// /appid/filename/subpath/userid
 using ConnKey = QString;
+// /appid/filename/subpath
 using ResourceKey = QString;
 using ConnServiceName = QString;
 using ConnRefCount = int;
 using ConfigCacheKey = QString;
+// /filename/subpath/userid
+using GeneralConfigFileKey = QString;
 
-inline QString getResourceKey(const ConnKey &connKey)
+static const QString EmptyAppId("");
+
+inline ResourceKey getResourceKey(const ConnKey &connKey)
 {
     return connKey.left(connKey.lastIndexOf('/'));
 }
 inline uint getConnectionKey(const ConnKey &connKey)
 {
     return connKey.mid(connKey.lastIndexOf('/') + 1).toUInt();
+}
+inline ConnKey getConnectionKey(const ResourceKey key, const uint uid)
+{
+    return QString("%1/%2").arg(key).arg(uid);
+}
+inline GeneralConfigFileKey getGeneralConfigKeyByConn(const ConnKey &connKey)
+{
+    return getResourceKey(connKey);
+}
+inline GeneralConfigFileKey getGeneralConfigKey(const ResourceKey &resouceKey, bool isGeneral)
+{
+    if (isGeneral)
+        return resouceKey;
+    return resouceKey.mid(resouceKey.indexOf('/', 1));
+}
+inline bool isTheResouceKey(const ResourceKey &r1, const ResourceKey &r2)
+{
+    return r1 == r2;
+}
+inline bool isGeneralResource(const QString &appid)
+{
+    return appid == EmptyAppId;
 }
 
 struct ConfigureId {

--- a/dconfig-center/dde-dconfig-daemon/dconfigconn.h
+++ b/dconfig-center/dde-dconfig-daemon/dconfigconn.h
@@ -28,15 +28,18 @@ public:
 
     virtual ~DSGConfigConn() override;
 
-    QString key() const;
+    ConnKey key() const;
 
     uint uid() const;
 
-    DTK_CORE_NAMESPACE::DConfigCache *cache() const;
+    QSharedPointer<DTK_CORE_NAMESPACE::DConfigCache> cache() const;
 
     void setConfigFile(DTK_CORE_NAMESPACE::DConfigFile *configFile);
 
-    void setConfigCache(DTK_CORE_NAMESPACE::DConfigCache *cache);
+    void setConfigCache(QSharedPointer<DTK_CORE_NAMESPACE::DConfigCache> cache);
+
+    void setGeneralConfigFile(DTK_CORE_NAMESPACE::DConfigFile *configFile);
+    void setGeneralConfigCache(DTK_CORE_NAMESPACE::DConfigCache *cache);
 
 Q_SIGNALS:
     void releaseChanged(const ConnServiceName &service);
@@ -68,9 +71,11 @@ private:
     bool contains(const QString &key);
 
 private:
-    DTK_CORE_NAMESPACE::DConfigFile *m_config;
-    DTK_CORE_NAMESPACE::DConfigCache *m_cache;
-    QString m_key;
+    DTK_CORE_NAMESPACE::DConfigFile *m_config = nullptr;
+    QSharedPointer<DTK_CORE_NAMESPACE::DConfigCache> m_cache = nullptr;
+    DTK_CORE_NAMESPACE::DConfigFile *m_generalConfig = nullptr;
+    DTK_CORE_NAMESPACE::DConfigCache *m_generalCache = nullptr;
+    ConnKey m_key;
     QSet<QString> m_keys;
 };
 

--- a/dconfig-center/dde-dconfig-daemon/dconfigresource.h
+++ b/dconfig-center/dde-dconfig-daemon/dconfigresource.h
@@ -19,6 +19,7 @@ DCORE_END_NAMESPACE
 DCORE_USE_NAMESPACE
 class DSGConfigConn;
 class ConfigSyncRequestCache;
+class DSGGeneralConfigManager;
 /**
  * @brief The DSGConfigResource class
  * 管理单个链接
@@ -36,11 +37,12 @@ public:
 
     void setSyncRequestCache(ConfigSyncRequestCache *cache);
 
-    DSGConfigConn* connObject(const uint uid);
+    DSGConfigConn* connObject(const uint uid) const;
+    DSGConfigConn* connObject(const ConnKey key) const;
 
     DSGConfigConn* createConn(const uint uid);
 
-    QString path() const;
+    ResourceKey path() const;
 
     QString getName() const;
 
@@ -53,6 +55,10 @@ public:
     void save();
 
     void doSyncConfigCache(const ConfigCacheKey &key);
+
+    bool isGeneralResource() const;
+    void setGeneralConfigManager(DSGGeneralConfigManager *ma);
+
 Q_SIGNALS: // SIGNALS
     void updateValueChanged(const QString &key);
 
@@ -61,6 +67,9 @@ Q_SIGNALS: // SIGNALS
     void releaseConn(const ConnServiceName &service, const ConnKey &connKey);
 
     void globalValueChanged(const QString &key);
+
+Q_SIGNALS:
+    void generalConfigValueChanged(const uint uid, const QString &key);
 
 public Q_SLOTS: // METHODS
     void onGlobalValueChanged(const QString &key);
@@ -76,14 +85,20 @@ private:
     QString getConnKey(const uint uid) const;
 
     void repareCache(DConfigCache* cache, DConfigMeta *oldMeta, DConfigMeta *newMeta);
+    bool setGeneralConfigForConn(DSGConfigConn *conn);
+    QSharedPointer<DConfigFile> getOrCreateConfig(bool *isCreate = nullptr) const;
+    QSharedPointer<DConfigCache> getOrCreateCache(const uint uid, bool *isCreate = nullptr) const;
+
 private:
-    QString m_path;
+    ResourceKey m_path;
     QString m_localPrefix;
-    QScopedPointer<DConfigFile> m_config;
+    QSharedPointer<DConfigFile> m_config;
     QMap<ConnKey, DSGConfigConn*> m_conns;
+    ResourceConfig *m_configs = nullptr;
     QString m_appid;
     QString m_fileName;
     QString m_subpath;
     ConfigSyncRequestCache *m_syncRequestCache = nullptr;
+    DSGGeneralConfigManager *m_generalConfigManager = nullptr;
 };
 

--- a/dconfig-center/dde-dconfig-daemon/dconfigserver.h
+++ b/dconfig-center/dde-dconfig-daemon/dconfigserver.h
@@ -14,6 +14,7 @@ class DSGConfigResource;
 class RefManager;
 class ConfigSyncBatchRequest;
 class ConfigSyncRequestCache;
+class DSGGeneralConfigManager;
 /**
  * @brief The DSGConfigServer class
  * 管理配置策略服务
@@ -67,6 +68,8 @@ private Q_SLOTS:
 
     void doSyncConfigCache(const ConfigSyncBatchRequest &request);
 
+    void doUpdateGeneralConfigValueChanged(const QString &key, const ConnKey &connKey);
+
 private:
     ResourceKey getResourceKeyByConfigCache(const ConfigCacheKey &key);
 
@@ -86,4 +89,5 @@ private:
     QString m_localPrefix;
     bool m_enableExit = false;
     ConfigSyncRequestCache *m_syncRequestCache = nullptr;
+    DSGGeneralConfigManager *m_generalConfigManager = nullptr;
 };

--- a/dconfig-center/dde-dconfig-daemon/dgeneralconfigmanager.cpp
+++ b/dconfig-center/dde-dconfig-daemon/dgeneralconfigmanager.cpp
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: 2023 Uniontech Software Technology Co.,Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "dgeneralconfigmanager.h"
+#include "dconfigfile.h"
+#include <QDebug>
+
+GeneralConfig::~GeneralConfig()
+{
+    m_caches.clear();
+}
+
+QSharedPointer<DConfigCache> GeneralConfig::cache(const uint uid) const
+{
+    return m_caches.value(uid);
+}
+
+bool GeneralConfig::contains(const uint id) const
+{
+    return m_caches.contains(id);
+}
+
+void GeneralConfig::removeCache(const uint uid)
+{
+    const auto iter = m_caches.find(uid);
+    if (iter != m_caches.end()) {
+        m_caches.erase(iter);
+    }
+}
+
+void GeneralConfig::addCache(const uint uid, QSharedPointer<DConfigCache> cache)
+{
+    Q_ASSERT(cache);
+    m_caches[uid] = cache;
+}
+
+void GeneralConfig::setConfig(QSharedPointer<DConfigFile> config)
+{
+    m_config = config;
+}
+
+QSharedPointer<DConfigFile> GeneralConfig::config() const
+{
+    return m_config;
+}
+
+DSGGeneralConfigManager::DSGGeneralConfigManager(QObject *parent)
+    : QObject (parent)
+{
+
+}
+
+DSGGeneralConfigManager::~DSGGeneralConfigManager()
+{
+    for (auto item : m_generalConfigs) {
+        delete item;
+    }
+    m_generalConfigs.clear();
+}
+
+GeneralConfig *DSGGeneralConfigManager::config(const GeneralConfigFileKey &key) const
+{
+    return m_generalConfigs.value(key);
+}
+
+bool DSGGeneralConfigManager::contains(const GeneralConfigFileKey &key) const
+{
+    return m_generalConfigs.contains(key);
+}
+
+GeneralConfig *DSGGeneralConfigManager::createConfig(const GeneralConfigFileKey &key)
+{
+    auto iter = m_generalConfigs.find(key);
+    if (iter != m_generalConfigs.end())
+        return *iter;
+
+    auto config = new GeneralConfig();
+    m_generalConfigs[key] = config;
+    return config;
+}
+
+void DSGGeneralConfigManager::removeConfig(const GeneralConfigFileKey &key)
+{
+    const auto iter = m_generalConfigs.find(key);
+    if (iter != m_generalConfigs.end()) {
+        delete iter.value();
+        m_generalConfigs.erase(iter);
+    }
+}

--- a/dconfig-center/dde-dconfig-daemon/dgeneralconfigmanager.h
+++ b/dconfig-center/dde-dconfig-daemon/dgeneralconfigmanager.h
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: 2023 Uniontech Software Technology Co.,Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include "dconfig_global.h"
+#include <dtkcore_global.h>
+#include <DConfigFile>
+#include <QObject>
+
+DCORE_BEGIN_NAMESPACE
+class DConfigFile;
+class DConfigCache;
+DCORE_END_NAMESPACE
+
+DCORE_USE_NAMESPACE
+/**
+ * @brief The GeneralConfig class
+ * 管理单个资源的公共配置信息
+ * 与DSGConfigResource类似，含有一个DConfigFile及多个DConfigCache.
+ */
+class GeneralConfig
+{
+public:
+    ~GeneralConfig();
+    QSharedPointer<DConfigCache> cache(const uint uid) const;
+    bool contains(const uint id) const;
+    void removeCache(const uint uid);
+    void addCache(const uint uid, QSharedPointer<DConfigCache> cache);
+    void setConfig(QSharedPointer<DConfigFile> config);
+    QSharedPointer<DConfigFile> config() const;
+private:
+    QSharedPointer<DConfigFile> m_config;
+    QMap<uint, QSharedPointer<DConfigCache>> m_caches;
+};
+
+/**
+ * @brief The DSGGeneralConfigManager class
+ * 管理公共资源
+ */
+class DSGGeneralConfigManager : public QObject
+{
+    Q_OBJECT
+public:
+    DSGGeneralConfigManager(QObject *parent = nullptr);
+    virtual ~DSGGeneralConfigManager() override;
+
+    GeneralConfig *config(const GeneralConfigFileKey &key) const;
+    bool contains(const GeneralConfigFileKey &key) const;
+    GeneralConfig *createConfig(const GeneralConfigFileKey &key);
+    void removeConfig(const GeneralConfigFileKey &key);
+
+Q_SIGNALS:
+    void valueChanged(const QString &key, const ConnKey &connKey);
+
+private:
+    QMap<GeneralConfigFileKey, GeneralConfig *> m_generalConfigs;
+};

--- a/dconfig-center/dde-dconfig-daemon/src.cmake
+++ b/dconfig-center/dde-dconfig-daemon/src.cmake
@@ -20,10 +20,12 @@ set(HEADERS
     ${CMAKE_CURRENT_LIST_DIR}/dconfigresource.h
     ${CMAKE_CURRENT_LIST_DIR}/dconfigconn.h
     ${CMAKE_CURRENT_LIST_DIR}/dconfigrefmanager.h
+    ${CMAKE_CURRENT_LIST_DIR}/dgeneralconfigmanager.h
 )
 set(SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/dconfigserver.cpp
     ${CMAKE_CURRENT_LIST_DIR}/dconfigresource.cpp
     ${CMAKE_CURRENT_LIST_DIR}/dconfigconn.cpp
     ${CMAKE_CURRENT_LIST_DIR}/dconfigrefmanager.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/dgeneralconfigmanager.cpp
 )

--- a/dconfig-center/dde-dconfig-editor/mainwindow.cpp
+++ b/dconfig-center/dde-dconfig-editor/mainwindow.cpp
@@ -35,6 +35,7 @@
 MainWindow::MainWindow(QWidget *parent) :
     DMainWindow(parent)
 {
+    appIdToNameMaps[VirtualAppId] = VirtualAppName;
     resize(800, 600);
     centralwidget = new QWidget(this);
     centralwidget->setObjectName(QStringLiteral("centralwidget"));
@@ -136,7 +137,7 @@ MainWindow::MainWindow(QWidget *parent) :
                 const auto &appid = model->data(index, ConfigUserRole + 2).toString();
                 const auto &resourceId = model->data(index, ConfigUserRole + 3).toString();
                 const auto &subpath = model->data(index, ConfigUserRole + 4).toString();
-                if (appid.isEmpty() || resourceId.isEmpty()) {
+                if (resourceId.isEmpty()) {
                     qWarning() << "error" << appid << resourceId;
                     return;
                 }
@@ -199,7 +200,7 @@ void MainWindow::refreshApps(const QString &matchAppid)
         }
 
         if (resourcesForApp(app).isEmpty()) {
-            continue;
+//            continue;
         }
 
         DStandardItem *item = new DStandardItem(app);
@@ -211,6 +212,7 @@ void MainWindow::refreshApps(const QString &matchAppid)
     }
     appListView->setModel(model);
     translateAppName();
+    refreshAppTranslate();
 }
 
 void MainWindow::refreshAppResources(const QString &appid, const QString &matchResource)
@@ -654,7 +656,7 @@ HistoryDialog::HistoryDialog(QWidget *parent)
     : DDialog( parent)
 {
     historyView = new DListView();
-    historyView->setModel(new QStandardItemModel());
+    historyView->setModel(new QStandardItemModel(this));
     historyView->setEditTriggers(QAbstractItemView::NoEditTriggers);
     addContent(historyView);
     connect(historyView, &DListView::doubleClicked, this, [this](const QModelIndex &index){

--- a/dconfig-center/dde-dconfig/CMakeLists.txt
+++ b/dconfig-center/dde-dconfig/CMakeLists.txt
@@ -6,8 +6,8 @@ PROJECT(dde-dconfig)
 CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
 
 set(REQUIRED_QT_VERSION 5.11.3)
-find_package(Qt5 ${REQUIRED_QT_VERSION} REQUIRED COMPONENTS Core Gui DBus)
-find_package(DtkWidget REQUIRED)
+find_package(Qt5 ${REQUIRED_QT_VERSION} REQUIRED COMPONENTS Core DBus)
+find_package(DtkCore REQUIRED)
 
 # generate moc_predefs.h
 set(CMAKE_AUTOMOC ON)
@@ -39,9 +39,8 @@ ADD_EXECUTABLE(dde-dconfig ${HEADERS} ${SOURCES} ${DCONFIG_DBUS_XML})
 
 set(COMMON_LIBS
     Qt5::Core
-    Qt5::Gui
     Qt5::DBus
-    ${DtkWidget_LIBRARIES}
+    ${DtkCore_LIBRARIES}
 )
 
 target_link_libraries(${PROJECT_NAME} PUBLIC ${COMMON_LIBS})
@@ -49,7 +48,7 @@ target_link_libraries(${PROJECT_NAME} PUBLIC ${COMMON_LIBS})
 target_include_directories(${PROJECT_NAME} PUBLIC
     ${CMAKE_CURRENT_BINARY_DIR}
     ${CMAKE_SOURCE_DIR}
-    ${DtkWidget_INCLUDE_DIRS}
+    ${DtkCore_INCLUDE_DIRS}
     ../common
 )
 

--- a/dconfig-center/example/main.cpp
+++ b/dconfig-center/example/main.cpp
@@ -20,6 +20,7 @@ public:
         watchValueChanged();
         subpath();
         mutilFetchConfig();
+        generalConfig();
     }
 
     void watchValueChanged()
@@ -104,6 +105,31 @@ public:
         {
             DConfig config(fileName);
             qDebug() << config.value("map", map);
+        }
+    }
+
+    void generalConfig()
+    {
+        // 空appid，直接获取公共配置
+        {
+            auto config = DConfig::create("", fileName);
+            qDebug() << config->value("canExit");
+        }
+        // 空appid，设置公共配置
+        {
+            auto config = DConfig::create("", fileName);
+            config->setValue("canExit", true);
+            qDebug() << config->value("canExit");
+        }
+        // 默认使用本appid去获取，会fallback到公共配置
+        {
+            DConfig config(fileName);
+            qDebug() << config.value("canExit");
+        }
+        // 指定使用appid去获取，会fallback到公共配置
+        {
+            auto config = DConfig::create("dconfig-example", fileName);
+            qDebug() << config->value("canExit");
         }
     }
 


### PR DESCRIPTION
  Add empty appid's support.
  it's used to set a general configuration, and all application
read the same configuration, also application can write itself's configuration to reject fallback to general configuration. it's similar to system xsetting's configuration.

Log: 空appid的配置项作为所有应用的fallback值, 用户级别的所有应用共用同一个
配置，公共库提供配置，可以由某个应用写，其它应用不传递appid而读取同一个配置
Influence: none
Change-Id: I5e452beb8e691573de9f95f059f328427a53628a

Change-Id: I759e18a3393f16a8657ce48af796f70fad8b3d29