### PR TITLE
fix: fix security issue

### DIFF
--- a/dconfig-center/dde-dconfig-daemon/services/org.desktopspec.ConfigManager.conf
+++ b/dconfig-center/dde-dconfig-daemon/services/org.desktopspec.ConfigManager.conf
@@ -4,8 +4,8 @@
  "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
  "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
 <busconfig>
-   <!-- Only root can own the service -->
-  <policy user="root">
+   <!-- Everybody is allowed to own the service on the D-Bus system bus -->
+  <policy user="dde-dconfig-daemon">
     <allow own="org.desktopspec.ConfigManager"/>
   </policy>
  <!-- Allow anyone to invoke methods on the interfaces -->

--- a/dconfig-center/dde-dconfig-daemon/services/org.desktopspec.ConfigManager.service
+++ b/dconfig-center/dde-dconfig-daemon/services/org.desktopspec.ConfigManager.service
@@ -1,4 +1,4 @@
 [D-BUS Service]
 Name=org.desktopspec.ConfigManager
 Exec=/usr/bin/dde-dconfig-daemon
-User=root
+User=dde-dconfig-daemon

--- a/debian/postinst
+++ b/debian/postinst
@@ -1,0 +1,6 @@
+#!/bin/sh -e
+
+getent group dde-dconfig-daemon >/dev/null || /usr/sbin/groupadd --system dde-dconfig-daemon
+getent passwd dde-dconfig-daemon >/dev/null || /usr/sbin/useradd --system -c "dde-dconfig-daemon User" \
+        -d /var/lib/dde-dconfig-daemon -m -g dde-dconfig-daemon -s /usr/sbin/nologin \
+        -G dde-dconfig-daemon dde-dconfig-daemon


### PR DESCRIPTION
Don't run dbus service by root

Log: Everybody is allowed to own the service on the D-Bus system bus.