### PR TITLE
feat: Support empty appid as interapp configure

### DIFF
--- a/dconfig-center/common/helper.hpp
+++ b/dconfig-center/common/helper.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2022 Uniontech Software Technology Co.,Ltd.
+// SPDX-FileCopyrightText: 2021 - 2023 Uniontech Software Technology Co.,Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -27,6 +27,8 @@ constexpr int SubpathRole = Qt::UserRole + 13;
 constexpr int KeyRole = Qt::UserRole + 14;
 constexpr int ValueRole = Qt::UserRole + 15;
 constexpr int DescriptionRole = Qt::UserRole + 16;
+static const QString NoAppId;
+static const QString VirtualAppName("virtual-generic-applicaiton");
 
 enum ConfigType {
     InvalidType = 0x00,
@@ -57,6 +59,8 @@ static QString resourcePath(const QString &appid, const QString &localPrefix = Q
 static AppList applications(const QString &localPrefix = QString())
 {
     AppList result;
+    result << NoAppId;
+
     result.reserve(50);
 
     // TODO calling service interface to get app list,

--- a/dconfig-center/dde-dconfig-daemon/dconfig_global.h
+++ b/dconfig-center/dde-dconfig-daemon/dconfig_global.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2022 Uniontech Software Technology Co.,Ltd.
+// SPDX-FileCopyrightText: 2021 - 2023 Uniontech Software Technology Co.,Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -11,6 +11,7 @@
 #include <QRegularExpression>
 #include <DStandardPaths>
 #include <QLoggingCategory>
+#include "helper.hpp"
 
 Q_DECLARE_LOGGING_CATEGORY(cfLog);
 
@@ -25,17 +26,23 @@ using ConnRefCount = int;
 // user: u-${ConnKey}, global: g-${ResourceKey}
 using ConfigCacheKey = QString;
 static constexpr int TestUid = 0U;
+static const QString VirtualInterAppId = "_";
+
 inline QString formatDBusObjectPath(QString path)
 {
     return path.replace('.', '_').replace('-', '_');
 }
 inline QString outerAppidToInner(const QString &appid)
 {
-    return appid;
+    return appid == NoAppId ? VirtualInterAppId : appid;
 }
 inline QString innerAppidToOuter(const QString &appid)
 {
-    return appid;
+    return appid == VirtualInterAppId ? NoAppId : appid;
+}
+inline bool isGenericResourceConn(const ConnKey &connKey)
+{
+    return connKey.startsWith("/" + VirtualInterAppId);
 }
 inline ResourceKey getResourceKey(const QString &appid, const GenericResourceKey &key)
 {

--- a/dconfig-center/dde-dconfig-daemon/dconfigresource.h
+++ b/dconfig-center/dde-dconfig-daemon/dconfigresource.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2022 Uniontech Software Technology Co.,Ltd.
+// SPDX-FileCopyrightText: 2021 - 2023 Uniontech Software Technology Co.,Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -27,10 +27,10 @@ class DSGConfigResource : public QObject
 {
     Q_OBJECT
 public:
-    explicit DSGConfigResource(const GenericResourceKey &key, const QString &localPrefix = QString(), QObject *parent = nullptr);
+    explicit DSGConfigResource(const QString &name, const QString &subpath, const QString &localPrefix = QString(), QObject *parent = nullptr);
     virtual ~DSGConfigResource() override;
 
-    bool load(const QString &appid, const QString &name, const QString &subpath);
+    bool load(const QString &appid);
 
     GenericResourceKey key() const;
     DConfigFile *getFile(const ResourceKey &key) const;
@@ -42,6 +42,11 @@ public:
     void removeConn(const ConnKey &connKey);
     bool isEmptyConn() const;
     ConnKey getConnKey(const QString &appid, const uint uid) const;
+    int connSize() const;
+
+    bool fallbackToGenericConfig() const;
+    DConfigCache *noAppidCache(const uint uid) const;
+    DConfigFile *noAppidFile() const;
 
     void save();
     void save(const QString &appid);
@@ -63,20 +68,24 @@ private Q_SLOTS:
 
 private:
     void repareCache(DConfigCache *cache, DConfigMeta *oldMeta, DConfigMeta *newMeta);
+
+    void doUpdateGenericConfigValueChanged(const QString &key, const ConnKey &connKey);
+
     void doGlobalValueChanged(const QString &key, const ResourceKey &resourceKey);
 
     DConfigFile *getOrCreateFile(const QString &appid);
     DConfigCache *createCache(const QString &appid, const uint uid);
     DConfigCache *getOrCreateCache(const QString &appid, const uint uid);
+    QList<DSGConfigConn *> specificAppConns() const;
     bool cacheExist(const ResourceKey &key) const;
     QList<DConfigCache *> cachesOfTheResource(const ResourceKey &resourceKey) const;
     QList<DSGConfigConn *> connsOfTheResource(const ResourceKey &resourceKey) const;
 
 private:
-    QString m_localPrefix;
     GenericResourceKey m_key;
     QString m_fileName;
     QString m_subpath;
+    QString m_localPrefix;
 
     QMap<ResourceKey, DConfigFile *> m_files;
     QMap<ConnKey, DConfigCache *> m_caches;

--- a/dconfig-center/dde-dconfig-daemon/dconfigserver.cpp
+++ b/dconfig-center/dde-dconfig-daemon/dconfigserver.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2022 Uniontech Software Technology Co.,Ltd.
+// SPDX-FileCopyrightText: 2021 - 2023 Uniontech Software Technology Co.,Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -135,11 +135,11 @@ QDBusObjectPath DSGConfigServer::acquireManager(const QString &appid, const QStr
     DSGConfigResource *resource = resourceObject(genericResourceKey);
     QScopedPointer<DSGConfigResource> resourceHolder;
     if (!resource) {
-        resource = new DSGConfigResource(genericResourceKey, m_localPrefix);
+        resource = new DSGConfigResource(name, subpath, m_localPrefix);
         resource->setSyncRequestCache(m_syncRequestCache);
         resourceHolder.reset(resource);
     }
-    bool loadStatus = resource->load(innerAppid, name, subpath);
+    bool loadStatus = resource->load(innerAppid);
     if (!loadStatus) {
         //error
         QString errorMsg = QString("Can't load resource: %1, for the appid:[%2].").arg(genericResourceKey).arg(appid);

--- a/dconfig-center/dde-dconfig-editor/mainwindow.cpp
+++ b/dconfig-center/dde-dconfig-editor/mainwindow.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2022 Uniontech Software Technology Co.,Ltd.
+// SPDX-FileCopyrightText: 2021 - 2023 Uniontech Software Technology Co.,Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -35,6 +35,7 @@
 MainWindow::MainWindow(QWidget *parent) :
     DMainWindow(parent)
 {
+    appIdToNameMaps[NoAppId] = VirtualAppName;
     resize(800, 600);
     centralwidget = new QWidget(this);
     centralwidget->setObjectName(QStringLiteral("centralwidget"));
@@ -136,7 +137,7 @@ MainWindow::MainWindow(QWidget *parent) :
                 const auto &appid = model->data(index, ConfigUserRole + 2).toString();
                 const auto &resourceId = model->data(index, ConfigUserRole + 3).toString();
                 const auto &subpath = model->data(index, ConfigUserRole + 4).toString();
-                if (appid.isEmpty() || resourceId.isEmpty()) {
+                if (resourceId.isEmpty()) {
                     qWarning() << "error" << appid << resourceId;
                     return;
                 }
@@ -211,6 +212,7 @@ void MainWindow::refreshApps(const QString &matchAppid)
     }
     appListView->setModel(model);
     translateAppName();
+    refreshAppTranslate();
 }
 
 void MainWindow::refreshAppResources(const QString &appid, const QString &matchResource)
@@ -218,7 +220,7 @@ void MainWindow::refreshAppResources(const QString &appid, const QString &matchR
     auto model = new QStandardItemModel(resourceListView);
     resourceListView->reset();
 
-    const auto &resources = resourcesForApp(appid);
+    const auto &resources = appid == NoAppId ? ResourceList() : resourcesForApp(appid);
 
     for (auto resource : resources) {
         if (!matchResource.isEmpty() && !resource.contains(matchResource, Qt::CaseInsensitive)) {

--- a/dconfig-center/dde-dconfig/main.cpp
+++ b/dconfig-center/dde-dconfig/main.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2022 Uniontech Software Technology Co.,Ltd.
+// SPDX-FileCopyrightText: 2021 - 2023 Uniontech Software Technology Co.,Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -56,7 +56,8 @@ int main(int argc, char *argv[])
     QCommandLineOption listOption("list", QCoreApplication::translate("main", "list configure information with appid, resource or subpath."));
     parser.addOption(listOption);
 
-    QCommandLineOption appidOption("a", QCoreApplication::translate("main", "appid for the configure owner application."), "appid", QString());
+    QCommandLineOption appidOption("a", QCoreApplication::translate("main", "appid for a specific application.\n"
+                                                                            "it is empty string if we need to manage application independent configuration."), "appid", QString());
     parser.addOption(appidOption);
 
     QCommandLineOption resourceOption("r", QCoreApplication::translate("main", "resource id for configure name."), "resource", QString());

--- a/dconfig-center/example/main.cpp
+++ b/dconfig-center/example/main.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2022 Uniontech Software Technology Co.,Ltd.
+// SPDX-FileCopyrightText: 2021 - 2023 Uniontech Software Technology Co.,Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -20,6 +20,7 @@ public:
         watchValueChanged();
         subpath();
         mutilFetchConfig();
+        generalConfig();
     }
 
     void watchValueChanged()
@@ -37,7 +38,9 @@ public:
             qDebug() << "value changed, oldValue:" << oldValue << ", newValue:" << heapConfig->value(key).toBool();
         });
 
+        // reset
         heapConfig->setValue("canExit", !oldValue);
+        heapConfig->reset("canExit");
     }
 
     void baseAPI()
@@ -66,7 +69,7 @@ public:
         config.setValue("canExit", false);
 
         // 重置指定配置项的值
-//        config.reset("canExit");
+        config.reset("canExit");
     }
 
     void subpath()
@@ -104,6 +107,40 @@ public:
         {
             DConfig config(fileName);
             qDebug() << config.value("map", map);
+        }
+        // reset
+        {
+            DConfig config(fileName);
+            config.reset("map");
+        }
+    }
+    void generalConfig()
+    {
+        // 空appid，直接获取公共配置
+        {
+            QScopedPointer<DConfig> config(DConfig::createGeneric(fileName));
+            qDebug() << config->value("canExit");
+        }
+        // 空appid，设置公共配置
+        {
+            QScopedPointer<DConfig> config(DConfig::createGeneric(fileName));
+            config->setValue("canExit", true);
+            qDebug() << config->value("canExit");
+        }
+        // 默认使用本appid去获取，会fallback到公共配置
+        {
+            DConfig config(fileName);
+            qDebug() << config.value("canExit");
+        }
+        // 指定使用appid去获取，会fallback到公共配置
+        {
+            QScopedPointer<DConfig> config(DConfig::create("noexist-appid", fileName));
+            qDebug() << config->value("canExit");
+        }
+        // reset
+        {
+            QScopedPointer<DConfig> config(DConfig::createGeneric(fileName));
+            config->reset("canExit");
         }
     }
 

--- a/dconfig-center/tests/ut_dconfigserver.cpp
+++ b/dconfig-center/tests/ut_dconfigserver.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2022 Uniontech Software Technology Co.,Ltd.
+// SPDX-FileCopyrightText: 2021 - 2023 Uniontech Software Technology Co.,Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -10,12 +10,14 @@
 
 #include <gtest/gtest.h>
 
+#include <DConfigFile>
+
 #include "dconfigserver.h"
 #include "dconfigresource.h"
 #include "dconfigconn.h"
 #include "test_helper.hpp"
 
-
+DCORE_USE_NAMESPACE
 static EnvGuard dsgDataDir;
 static constexpr char const *LocalPrefix = "/tmp/example/";
 static constexpr char const *APP_ID = "org.foo.appid";
@@ -31,11 +33,13 @@ protected:
         }
 
         ASSERT_TRUE(QFile::copy(":/config/example.json", path));
+        ASSERT_TRUE(QFile::copy(":/config/example.json", noAppIdConfigPath()));
         qputenv("DSG_CONFIG_CONNECTION_DISABLE_DBUS", "true");
         dsgDataDir.set("DSG_DATA_DIRS", "/usr/share/dsg");
     }
     static void TearDownTestCase() {
         QFile::remove(configPath());
+        QFile::remove(noAppIdConfigPath());
         qunsetenv("DSG_CONFIG_CONNECTION_DISABLE_DBUS");
         QDir(LocalPrefix).removeRecursively();
         dsgDataDir.restore();
@@ -51,7 +55,14 @@ protected:
         const QString metaPath = QString("%1/usr/share/dsg/configs/%2").arg(LocalPrefix, APP_ID);
 
         return QString("%1/%2.json").arg(metaPath, FILE_NAME);
-    }    QScopedPointer<DSGConfigServer> server;
+    }
+    static QString noAppIdConfigPath()
+    {
+        const QString metaPath = QString("%1/usr/share/dsg/configs/").arg(LocalPrefix);
+
+        return QString("%1/%2.json").arg(metaPath, FILE_NAME);
+    }
+    QScopedPointer<DSGConfigServer> server;
 };
 
 void ut_DConfigServer::TearDown() {
@@ -66,7 +77,6 @@ TEST_F(ut_DConfigServer, acquireManager) {
     auto path2 = server->acquireManager(APP_ID, "example_noexist", QString("")).path();
     ASSERT_EQ(server->resourceObject(path2), nullptr);
     ASSERT_EQ(server->resourceSize(), 1);
-
 }
 
 TEST_F(ut_DConfigServer, resourceSize) {
@@ -158,4 +168,21 @@ TEST_F(ut_DConfigServer, overridePathToConfigureId) {
         const auto configureId = getOverrideConfigureId(path);
         ASSERT_FALSE(configureId.isInValid());
     }
+}
+
+TEST_F(ut_DConfigServer, acquireManagerGeneric) {
+    ASSERT_EQ(server->acquireManager(NoAppId, FILE_NAME, QString("")).path(),
+              formatDBusObjectPath(QString("/%1/%2/%3").arg(VirtualInterAppId, FILE_NAME, QString::number(TestUid))));
+
+    ASSERT_EQ(server->resourceSize(), 1);
+    server->acquireManager(APP_ID, FILE_NAME, QString(""));
+    ASSERT_EQ(server->resourceSize(), 1);
+
+    const auto path1 = server->acquireManager(NoAppId, FILE_NAME, QString("")).path();
+    const auto path2 = server->acquireManager(APP_ID, FILE_NAME, QString("")).path();
+    const auto resource = server->resourceObject(getGenericResourceKey(path1));
+    ASSERT_EQ(resource, server->resourceObject(getGenericResourceKey(path2)));
+    auto conn = resource->getConn(VirtualInterAppId, TestUid);
+    ASSERT_TRUE(conn);
+    ASSERT_EQ(resource->connSize(), 2);
 }

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Build-Depends:
  cmake,
  qtbase5-dev,
  libdtkcommon-dev,
- libdtkcore-dev,
+ libdtkcore-dev(>5.6.5),
  libdtkgui-dev,
  libdtkwidget-dev,
  libgtest-dev


### PR DESCRIPTION
  fallback to generic configuration if application is not changed,
and if generic configuration is changed, it will emit all related application's valueChanged.

Log: none
Influence: none
Change-Id: I90ad3bf631f69eb93445212a5cb6fab1c4ad1ec7