### PR TITLE
feat: Relocate cache position

### DIFF
--- a/dconfig-center/dde-dconfig-daemon/dconfigresource.cpp
+++ b/dconfig-center/dde-dconfig-daemon/dconfigresource.cpp
@@ -235,6 +235,7 @@ DConfigFile *DSGConfigResource::getOrCreateFile(const QString &appid)
         return file;
 
     QScopedPointer<DConfigFile> file(new DConfigFile(innerAppidToOuter(appid), m_fileName, m_subpath));
+    file->globalCache()->setCachePathPrefix(DStandardPaths::path(DStandardPaths::XDG::ConfigHome) + "/global");
     if (!file->load(m_localPrefix))
         return nullptr;
 
@@ -260,6 +261,7 @@ DConfigCache *DSGConfigResource::createCache(const QString &appid, const uint ui
     const auto resourceKey = getResourceKey(appid, m_key);
     if (auto file = getFile(resourceKey)) {
         QScopedPointer<DConfigCache> cache(file->createUserCache(uid));
+        cache->setCachePathPrefix(DStandardPaths::path(DStandardPaths::XDG::ConfigHome) + QString("/%1").arg(uid));
         if (cache->load(m_localPrefix))
             return cache.take();
     }

--- a/dconfig-center/dde-dconfig-daemon/main.cpp
+++ b/dconfig-center/dde-dconfig-daemon/main.cpp
@@ -52,11 +52,6 @@ int main(int argc, char *argv[])
 
     // Initialization of DtkCore needs to be later than `registerService` avoid earlier request itself.
     Dtk::Core::DLogManager::registerConsoleAppender();
-    Dtk::Core::DLogManager::setlogFilePath(QString("/var/log/%1/%2/%2.log").arg(a.organizationName(), a.applicationName()));
-    const QDir &logDir = QFileInfo((Dtk::Core::DLogManager::getlogFilePath())).dir();
-    if (!logDir.exists())
-        QDir().mkpath(logDir.path());
-
     Dtk::Core::DLogManager::registerFileAppender();
     qInfo() << "Log path is:" << Dtk::Core::DLogManager::getlogFilePath();
     QObject::connect(qApp, &QCoreApplication::aboutToQuit, [&dsgConfig]() {

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Build-Depends:
  cmake,
  qtbase5-dev,
  libdtkcommon-dev,
- libdtkcore-dev(>5.6.5),
+ libdtkcore-dev(>5.6.8),
  libdtkgui-dev,
  libdtkwidget-dev,
  libgtest-dev


### PR DESCRIPTION
  Relocate cache's position to dde-dconfig-daemon's home dir.
  It can remove dde-dconfig-daemon's root permission.

Log: 重定位缓存位置，以便能够移除dde-dconfig-daemon必须的root权限
Issue: https://github.com/linuxdeepin/dtkcore/issues/271