### PR TITLE
fix: Save cache invalided

### DIFF
--- a/dconfig-center/dde-dconfig-daemon/dconfig_global.h
+++ b/dconfig-center/dde-dconfig-daemon/dconfig_global.h
@@ -52,13 +52,17 @@ inline ResourceKey getResourceKey(const ConnKey &connKey)
 {
     return connKey.left(connKey.lastIndexOf('/'));
 }
+inline GenericResourceKey getGenericResourceKeyByResourceKey(const ResourceKey &resourceKey)
+{
+    return resourceKey.mid(resourceKey.indexOf('/', 1));
+}
 inline GenericResourceKey getGenericResourceKey(const QString &name, const QString &subpath)
 {
     return QString("/%1%2").arg(name, subpath);
 }
 inline GenericResourceKey getGenericResourceKey(const ConnKey &connKey)
 {
-    return getResourceKey(connKey).mid(connKey.indexOf('/', 1));
+    return getGenericResourceKeyByResourceKey(getResourceKey(connKey));
 }
 inline uint getConnectionKey(const ConnKey &connKey)
 {

--- a/dconfig-center/dde-dconfig-daemon/dconfigserver.cpp
+++ b/dconfig-center/dde-dconfig-daemon/dconfigserver.cpp
@@ -234,7 +234,8 @@ void DSGConfigServer::doSyncConfigCache(const ConfigSyncBatchRequest &request)
     qCInfo(cfLog()) << "do sync config cache, keys count:" << keys.size();
     for (auto key: keys) {
         auto resourceKey = getResourceKeyByConfigCache(key);
-        if (auto resource = m_resources.value(resourceKey)) {
+        const auto genericResourceKey = getGenericResourceKeyByResourceKey(resourceKey);
+        if (auto resource = m_resources.value(genericResourceKey)) {
             resource->doSyncConfigCache(key);
         }
     }


### PR DESCRIPTION
  resources's key is GenericResourceKey instead of ResourceKey.