### PR TITLE
fix: Cleaning resource When exiting manual

### DIFF
--- a/dconfig-center/dde-dconfig-daemon/dconfig_global.h
+++ b/dconfig-center/dde-dconfig-daemon/dconfig_global.h
@@ -135,8 +135,7 @@ public:
     typedef T* DataType;
     ~ObjectPool()
     {
-        qDeleteAll(m_pool);
-        m_pool.clear();
+        clear();
     }
     using InitFunc = std::function<void(DataType)>;
     void setInitFunc(InitFunc func) { m_initFunc = func;}
@@ -153,6 +152,12 @@ public:
         return m_pool.dequeue();
     }
     void push(DataType item) { m_pool.enqueue(item);}
+
+    void clear()
+    {
+        qDeleteAll(m_pool);
+        m_pool.clear();
+    }
 
 private:
     QQueue<DataType> m_pool;

--- a/dconfig-center/dde-dconfig-daemon/dconfigconn.cpp
+++ b/dconfig-center/dde-dconfig-daemon/dconfigconn.cpp
@@ -182,7 +182,7 @@ QDBusVariant DSGConfigConn::value(const QString &key)
 
     if (value.isNull()) {
         QString errorMsg = QString("[%1] Requires the value in [%2].").arg(key).arg(getAppid());
-        qWarning() << errorMsg;
+        qWarning() << qPrintable(errorMsg);
         if (calledFromDBus()) {
             sendErrorReply(QDBusError::Failed, errorMsg);
         }
@@ -236,7 +236,7 @@ bool DSGConfigConn::contains(const QString &key)
     QString errorMsg = QString("[%1] Requires Non-existent configure item [%2] in [%3].").arg(getAppid()).arg(key).arg(m_key);
     if (calledFromDBus())
         sendErrorReply(QDBusError::Failed, errorMsg);
-    qWarning() << errorMsg;
+    qWarning() << qPrintable(errorMsg);
 
     return false;
 }

--- a/dconfig-center/dde-dconfig-daemon/dconfigrefmanager.h
+++ b/dconfig-center/dde-dconfig-daemon/dconfigrefmanager.h
@@ -82,6 +82,7 @@ public:
     virtual ~ConfigSyncRequestCache() override;
 
     void pushRequest(const ConfigCacheKey& key);
+    void clear();
 
     static ConfigCacheKey globalKey(const ResourceKey &key);
     static ConfigCacheKey userKey(const ConnKey &key);

--- a/dconfig-center/dde-dconfig-daemon/dconfigresource.cpp
+++ b/dconfig-center/dde-dconfig-daemon/dconfigresource.cpp
@@ -391,8 +391,8 @@ void DSGConfigResource::repareCache(DConfigCache *cache, DConfigMeta *oldMeta, D
     const auto subtractKeys = oldKeyList - (newKeyList);
     for (const auto &key :subtractKeys) {
         cache->remove(key);
-        qDebug(cfLog()) << QString("Cache removed because of meta item removed. "
-                            "resource:%1,uid:%2,key:%3.").arg(m_key).arg(cache->uid()).arg(key);
+        qDebug(cfLog, "Cache removed because of meta item removed, resource:%s, uid:%d, key:%s.",
+               qPrintable(m_key), cache->uid(), qPrintable(key));
     }
     // 权限变化，ReadWrite -> ReadOnly，移除cache值
     auto intersectKeys = newKeyList;
@@ -401,8 +401,8 @@ void DSGConfigResource::repareCache(DConfigCache *cache, DConfigMeta *oldMeta, D
         if (newMeta->permissions(key) == DConfigFile::ReadOnly &&
                 oldMeta->permissions(key) == DConfigFile::ReadWrite) {
             cache->remove(key);
-            qDebug(cfLog()) << QString("Cache removed because of permissions changed from readwrite to readonly. "
-                                "resource:%1,uid:%2,key:%3.").arg(m_key).arg(cache->uid()).arg(key);
+            qDebug(cfLog, "Cache removed because of permissions changed from readwrite to readonly, resource:%s,uid:%d,key:%s.",
+                   qPrintable(m_key), cache->uid(), qPrintable(key));
         }
     }
 }
@@ -434,7 +434,7 @@ void DSGConfigResource::removeConn(const ConnKey &connKey)
         }
     }
 
-    qDebug(cfLog()) << QString("Removed connection:%1, remaining %2 connection.").arg(connKey).arg(m_conns.count());
+    qDebug(cfLog, "Removed connection:%s, remaining %d connection.", qPrintable(connKey), m_conns.count());
 }
 
 bool DSGConfigResource::isEmptyConn() const
@@ -444,6 +444,7 @@ bool DSGConfigResource::isEmptyConn() const
 
 void DSGConfigResource::save()
 {
+    qDebug(cfLog, "Save resource's cache for [%s], and cache count:%d", qPrintable(m_key), m_caches.count());
     for (auto item : m_files)
         item->save(m_localPrefix);
 

--- a/dconfig-center/dde-dconfig-daemon/dconfigserver.h
+++ b/dconfig-center/dde-dconfig-daemon/dconfigserver.h
@@ -74,9 +74,9 @@ private:
     // 所有链接，一个资源对应一个链接
     QMap<GenericResourceKey, DSGConfigResource *> m_resources;
 
-    QDBusServiceWatcher* m_watcher;
+    QDBusServiceWatcher *m_watcher = nullptr;
 
-    RefManager* m_refManager;
+    RefManager *m_refManager = nullptr;
 
     QString m_localPrefix;
     bool m_enableExit = false;

--- a/dconfig-center/dde-dconfig-daemon/main.cpp
+++ b/dconfig-center/dde-dconfig-daemon/main.cpp
@@ -44,9 +44,9 @@ int main(int argc, char *argv[])
     }
 
     if (dsgConfig.registerService()) {
-        qInfo() << "start dconfig daemon successfully.";
+        qInfo() << "Starting dconfig daemon succeeded.";
     } else {
-        qInfo() << "start dconfig daemon failed.";
+        qInfo() << "Starting dconfig daemon failed.";
         return 1;
     }
 
@@ -59,12 +59,16 @@ int main(int argc, char *argv[])
 
     Dtk::Core::DLogManager::registerFileAppender();
     qInfo() << "Log path is:" << Dtk::Core::DLogManager::getlogFilePath();
+    QObject::connect(qApp, &QCoreApplication::aboutToQuit, [&dsgConfig]() {
+        qInfo() << "Exit dconfig daemon and release resources.";
+        dsgConfig.exit();
+    });
 
     // 异常处理，调用QCoreApplication::exit，使DSGConfigServer正常析构。
     std::signal(SIGINT, &QCoreApplication::exit);
     std::signal(SIGABRT, &QCoreApplication::exit);
     std::signal(SIGTERM, &QCoreApplication::exit);
-    std::signal(SIGKILL, &QCoreApplication::exit) ;
+    std::signal(SIGKILL, &QCoreApplication::exit);
 
     return a.exec();
 }


### PR DESCRIPTION
  Modify log format.
  Call `exit` to clean resource when exiting.