### PR TITLE
chore: update version to 1.0.20

### DIFF
--- a/dconfig-center/CMakeLists.txt
+++ b/dconfig-center/CMakeLists.txt
@@ -10,6 +10,9 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 include(GNUInstallDirs)
 
+set(DVERSION "1.0.0" CACHE STRING "define project version")
+add_definitions(-DVERSION="${DVERSION}")
+
 add_subdirectory("dde-dconfig-daemon")
 add_subdirectory("dde-dconfig-editor")
 add_subdirectory("dde-dconfig")

--- a/dconfig-center/dde-dconfig-editor/CMakeLists.txt
+++ b/dconfig-center/dde-dconfig-editor/CMakeLists.txt
@@ -9,9 +9,6 @@ if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
     set(CMAKE_INSTALL_PREFIX /usr)
 endif ()
 
-set(DVERSION "1.0.0" CACHE STRING "define project version")
-add_definitions(-DVERSION="${DVERSION}")
-
 set(REQUIRED_QT_VERSION 5.11.3)
 find_package(Qt5 ${REQUIRED_QT_VERSION} REQUIRED COMPONENTS Core Gui Widgets DBus)
 find_package(DtkCore REQUIRED)

--- a/dconfig-center/dde-dconfig/main.cpp
+++ b/dconfig-center/dde-dconfig/main.cpp
@@ -45,7 +45,7 @@ int onWatchOption(const QCoreApplication &a, const QCommandLineParser &parser, c
 int main(int argc, char *argv[])
 {
     QCoreApplication a(argc, argv);
-    a.setApplicationVersion("1.0.0");
+    a.setApplicationVersion(VERSION);
 
     QCommandLineParser parser;
     parser.addHelpOption();

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-app-services (1.0.20) unstable; urgency=medium
+
+  * 1.0.20
+
+ --  Deepin Package Builder <packages@deepin.com>  Mon, 10 Apr 2023 14:13:40 +0800
+
 dde-app-services (0.0.23) unstable; urgency=medium
 
   * feat: Remove root user for dde-dconfig-daemon


### PR DESCRIPTION
1. update to 1.0.20 (gerrit/dde-app-services 1.0.19.2 ...)
2. dde-dconfig use VERSION application version