### PR TITLE
feat: Add systemd service

### DIFF
--- a/dconfig-center/dde-dconfig-daemon/CMakeLists.txt
+++ b/dconfig-center/dde-dconfig-daemon/CMakeLists.txt
@@ -46,6 +46,7 @@ install (FILES services/org.desktopspec.ConfigManager.conf DESTINATION ${CMAKE_I
 
 ## services files
 install(FILES services/org.desktopspec.ConfigManager.service DESTINATION ${CMAKE_INSTALL_DATADIR}/dbus-1/system-services)
+install(FILES services/dde-dconfig-daemon.service DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/systemd/system)
 
 ## bin
 install(TARGETS dde-dconfig-daemon DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/dconfig-center/dde-dconfig-daemon/services/dde-dconfig-daemon.service
+++ b/dconfig-center/dde-dconfig-daemon/services/dde-dconfig-daemon.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=dde-dconfig-daemon service
+
+[Service]
+Type=dbus
+User=dde-dconfig-daemon
+BusName=org.desktopspec.ConfigManager
+ExecStart=/usr/bin/dde-dconfig-daemon
+Environment=DSG_DATA_DIRS=/usr/share/dsg:/persistent/linglong/entries/share/dsg

--- a/dconfig-center/dde-dconfig-daemon/services/org.desktopspec.ConfigManager.service
+++ b/dconfig-center/dde-dconfig-daemon/services/org.desktopspec.ConfigManager.service
@@ -2,3 +2,4 @@
 Name=org.desktopspec.ConfigManager
 Exec=/usr/bin/dde-dconfig-daemon
 User=dde-dconfig-daemon
+SystemdService=dde-dconfig-daemon.service

--- a/debian/dde-dconfig-daemon.install
+++ b/debian/dde-dconfig-daemon.install
@@ -4,3 +4,4 @@ usr/share/bash-completion/completions/*
 usr/share/dbus-1/system.d/*
 usr/share/dbus-1/interfaces/*
 usr/share/dbus-1/system-services/*
+usr/lib/systemd/system/*


### PR DESCRIPTION
  Add systemd service to set `DSG_DATA_DIRS` for dde-dconfig-daemon.
It resoved that `linglong` applications can't access DConfig.

Issue: https://github.com/linuxdeepin/developer-center/issues/4161