### PR TITLE
feat: Manage user by sysusers.d to replace postinst

### DIFF
--- a/dconfig-center/dde-dconfig-daemon/CMakeLists.txt
+++ b/dconfig-center/dde-dconfig-daemon/CMakeLists.txt
@@ -48,5 +48,9 @@ install (FILES services/org.desktopspec.ConfigManager.conf DESTINATION ${CMAKE_I
 install(FILES services/org.desktopspec.ConfigManager.service DESTINATION ${CMAKE_INSTALL_DATADIR}/dbus-1/system-services)
 install(FILES services/dde-dconfig-daemon.service DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/systemd/system)
 
+## sysusers file
+install (FILES services/dde-dconfig-daemon.conf DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/sysusers.d)
+install (FILES services/dde-dconfig-daemon-tmpfiles.conf DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/tmpfiles.d)
+
 ## bin
 install(TARGETS dde-dconfig-daemon DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/dconfig-center/dde-dconfig-daemon/services/dde-dconfig-daemon-tmpfiles.conf
+++ b/dconfig-center/dde-dconfig-daemon/services/dde-dconfig-daemon-tmpfiles.conf
@@ -1,0 +1,6 @@
+# Fields: type; path; mode; uid; gid; age; argument (symlink target)
+
+# Make ${localstatedir}/lib/dde-dconfig-daemon (required for systemd < 237)
+# Adjust mode and ownership if it already exists.
+
+d /var/lib/dde-dconfig-daemon 0755 dde-dconfig-daemon - -

--- a/dconfig-center/dde-dconfig-daemon/services/dde-dconfig-daemon.conf
+++ b/dconfig-center/dde-dconfig-daemon/services/dde-dconfig-daemon.conf
@@ -1,0 +1,8 @@
+#  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+
+u dde-dconfig-daemon - "dde-dconfig-daemon user" /var/lib/dde-dconfig-daemon /usr/sbin/nologin

--- a/debian/dde-dconfig-daemon.sysusers
+++ b/debian/dde-dconfig-daemon.sysusers
@@ -1,0 +1,8 @@
+#  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+
+u dde-dconfig-daemon - "dde-dconfig-daemon user" /var/lib/dde-dconfig-daemon /usr/sbin/nologin

--- a/debian/dde-dconfig-daemon.tmpfiles
+++ b/debian/dde-dconfig-daemon.tmpfiles
@@ -1,0 +1,6 @@
+# Fields: type; path; mode; uid; gid; age; argument (symlink target)
+
+# Make ${localstatedir}/lib/dde-dconfig-daemon (required for systemd < 237)
+# Adjust mode and ownership if it already exists.
+
+d /var/lib/dde-dconfig-daemon 0755 dde-dconfig-daemon - -

--- a/debian/postinst
+++ b/debian/postinst
@@ -1,6 +1,0 @@
-#!/bin/sh -e
-
-getent group dde-dconfig-daemon >/dev/null || /usr/sbin/groupadd --system dde-dconfig-daemon
-getent passwd dde-dconfig-daemon >/dev/null || /usr/sbin/useradd --system -c "dde-dconfig-daemon User" \
-        -d /var/lib/dde-dconfig-daemon -m -g dde-dconfig-daemon -s /usr/sbin/nologin \
-        -G dde-dconfig-daemon dde-dconfig-daemon

--- a/debian/rules
+++ b/debian/rules
@@ -8,3 +8,9 @@ export QT_SELECT = qt5
 
 override_dh_auto_configure:
 	dh_auto_configure -- -DDVERSION=$(DEB_VERSION_UPSTREAM)
+
+
+override_dh_auto_install:
+	dh_auto_install
+	dh_installsysusers dde-dconfig-daemon.sysusers
+	dh_installtmpfiles dde-dconfig-daemon.tmpfiles


### PR DESCRIPTION
We have been used systemd, so we can use sysusers.d to manage
it's users and tmpfiles.d to manage homedir.
  postinst can't remove added user when uninstall, and it's
permissions also has some incorrectly.
  In debian, debian/dde-dconfig-daemon.sysusers is useful, user is
not created when install firstly even if conf is installed in
sysusers.d, we need reload systemd-sysusers manually.
  debian/dde-dconfig-daemon.sysusers is a hard link, and we should
override dh_auto_install, otherwise, `sysusers` is declaraed before
`tmpfiles` because user mentioned in tmpfiles.
