### PR TITLE
feat: Being consistent with dtkcore for meta dir

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Build-Depends:
  cmake,
  qtbase5-dev,
  libdtkcommon-dev,
- libdtkcore-dev(>5.6.8),
+ libdtkcore-dev(>5.6.12),
  libdtkgui-dev,
  libdtkwidget-dev,
  libgtest-dev


### PR DESCRIPTION
  `dde-dconfig` and `dde-dconfig-editor` have hard code for metadir,
now we replace it with dtkcore's interface.

Issue: https://github.com/linuxdeepin/dtk/issues/10