### PR TITLE
feat: Support runtime control of verbose log on/off switch

### DIFF
--- a/dconfig-center/dde-dconfig-daemon/dconfigserver.cpp
+++ b/dconfig-center/dde-dconfig-daemon/dconfigserver.cpp
@@ -104,6 +104,28 @@ int DSGConfigServer::delayReleaseTime() const
     return m_refManager->delayReleaseTime();
 }
 
+void DSGConfigServer::enableVerboseLogging()
+{
+    QByteArrayList rules{QString("%1.debug=true").arg(cfLog().categoryName()).toLocal8Bit()};
+    rules << "dtk.dsg.config.debug=true";
+    setLogRules(rules.join(';'));
+}
+
+void DSGConfigServer::disableVerboseLogging()
+{
+    setLogRules("");
+}
+
+void DSGConfigServer::setLogRules(const QString &rules)
+{
+    QByteArrayList result;
+    for (auto item : rules.split(";")) {
+        result << item.toLocal8Bit();
+    }
+    QLoggingCategory::setFilterRules(result.join('\n'));
+    qCInfo(cfLog(), "Set log filter rules to:\"%s\"", qPrintable(rules));
+}
+
 void DSGConfigServer::setLocalPrefix(const QString &localPrefix)
 {
     m_localPrefix = localPrefix;

--- a/dconfig-center/dde-dconfig-daemon/dconfigserver.h
+++ b/dconfig-center/dde-dconfig-daemon/dconfigserver.h
@@ -54,6 +54,10 @@ public Q_SLOTS:
     void setDelayReleaseTime(const int ms);
     int delayReleaseTime() const;
 
+    void enableVerboseLogging();
+    void disableVerboseLogging();
+    void setLogRules(const QString &rules);
+
 private Q_SLOTS:
     void onReleaseChanged(const ConnServiceName &service, const ConnKey &connKey);
 

--- a/dconfig-center/dde-dconfig-daemon/services/org.desktopspec.ConfigManager.xml
+++ b/dconfig-center/dde-dconfig-daemon/services/org.desktopspec.ConfigManager.xml
@@ -17,4 +17,11 @@
     <method name='delayReleaseTime'>
       <arg type='i' name='time' direction='out'/>
     </method>
+    <method name='enableVerboseLogging'>
+    </method>
+    <method name='disableVerboseLogging'>
+    </method>
+    <method name='setLogRules'>
+      <arg type='s' name='rules' direction='in'/>
+    </method>
 </interface>

--- a/dconfig-center/example/dbus-dconfig.sh
+++ b/dconfig-center/example/dbus-dconfig.sh
@@ -4,6 +4,9 @@
 #
 # SPDX-License-Identifier: LGPL-3.0-only
 
+# enableVerboseLogging, Enable verbose logging information output
+dbus-send --system --type=method_call --print-reply=literal --dest=org.desktopspec.ConfigManager / org.desktopspec.ConfigManager.enableVerboseLogging
+
 dbus-send --system --type=method_call --print-reply=literal --dest=org.desktopspec.ConfigManager / org.desktopspec.ConfigManager.setDelayReleaseTime int32:1000
 
 echo delayReleaseTime: $(dbus-send --system --type=method_call --print-reply=literal --dest=org.desktopspec.ConfigManager / org.desktopspec.ConfigManager.delayReleaseTime)
@@ -62,6 +65,8 @@ dbus-send --system --type=method_call --print-reply --dest=org.desktopspec.Confi
 #sync
 dbus-send --system --type=method_call --print-reply --dest=org.desktopspec.ConfigManager / org.desktopspec.ConfigManager.sync string:'/usr/share/dsg/configs/dconfig-example/example.json'
 
+# disableVerboseLogging, Disable verbose logging information output
+dbus-send --system --type=method_call --print-reply=literal --dest=org.desktopspec.ConfigManager / org.desktopspec.ConfigManager.disableVerboseLogging
 
 # killall dbus-monitor
 # kill $DBUS_MONITOR_PID


### PR DESCRIPTION
  For the convenience of debugging, we use QLoggingCategory::
setFilterRules to change log's rules.