### PR TITLE
fix: Wrong value for negative float type in editor

### DIFF
--- a/dconfig-center/dde-dconfig-editor/mainwindow.cpp
+++ b/dconfig-center/dde-dconfig-editor/mainwindow.cpp
@@ -628,7 +628,7 @@ void KeyContent::setBaseInfo(ConfigGetter *getter, const QString &language)
         valueWidget = widget;
     } else if (valueType == QVariant::Double) {
         auto widget = new DDoubleSpinBox(this);
-        widget->setRange(std::numeric_limits<double>::min(), std::numeric_limits<double>::max());
+        widget->setRange(std::numeric_limits<double>::lowest(), std::numeric_limits<double>::max());
         widget->setValue(v.toDouble());
         widget->setEnabled(canWrite);
         connect(widget, SIGNAL(valueChanged(double)), this, SLOT(onDoubleValueChanged(double)));


### PR DESCRIPTION
  Only positive value for `min()`