### PR TITLE
feat: Support positional argument for dde-dconfig

### DIFF
--- a/dconfig-center/dde-dconfig-editor/exportdialog.cpp
+++ b/dconfig-center/dde-dconfig-editor/exportdialog.cpp
@@ -208,12 +208,12 @@ QList<QStringList> ExportDialog::exportData()
             data << item->data(KeyRole).toString();
             data << item->data(ValueRole).toString();
             data << item->data(DescriptionRole).toString();
-            QString setCmd = QString("dde-dconfig --set -a %1 -r %2 -k %3 -v %4").
+            QString setCmd = QString("dde-dconfig set %1 -r %2 %3 -v %4").
                              arg(item->data(AppidRole).toString()).
                              arg(item->data(ResourceRole).toString()).
                              arg(item->data(KeyRole).toString()).
                              arg(item->data(ValueRole).toString());
-            QString getCmd = QString("dde-dconfig --get -a %1 -r %2 -k %3").
+            QString getCmd = QString("dde-dconfig get %1 -r %2 %3").
                              arg(item->data(AppidRole).toString()).
                              arg(item->data(ResourceRole).toString()).
                              arg(item->data(KeyRole).toString());

--- a/dconfig-center/dde-dconfig-editor/mainwindow.cpp
+++ b/dconfig-center/dde-dconfig-editor/mainwindow.cpp
@@ -545,8 +545,8 @@ void Content::onCustomContextMenuRequested(QWidget *widget, const QString &appid
     QAction *copyCmdAction = menu->addAction("复制命令");
     QAction *resetCmdAction = menu->addAction("重置");
 
-    QString setCmd = QString("dde-dconfig --set -a %1 -r %2 -k %3 -v %4").arg(appid).arg(resource).arg(key).arg(value);
-    QString getCmd = QString("dde-dconfig --get -a %1 -r %2  -k %3").arg(appid).arg(resource).arg(key);
+    QString setCmd = QString("dde-dconfig set %1 -r %2 %3 -v %4").arg(appid).arg(resource).arg(key).arg(value);
+    QString getCmd = QString("dde-dconfig get %1 -r %2 %3").arg(appid).arg(resource).arg(key);
     if (!subpath.isEmpty()) {
         setCmd.append(QString(" -s %1").arg(subpath));
         getCmd.append(QString(" -s %1").arg(subpath));

--- a/dconfig-center/dde-dconfig/bash_completion.d/dde-dconfig
+++ b/dconfig-center/dde-dconfig/bash_completion.d/dde-dconfig
@@ -8,16 +8,31 @@ _dde_dconfig()
 {
     COMPREPLY=()
     local cur=${COMP_WORDS[COMP_CWORD]};
-    local cmd=${COMP_WORDS[COMP_CWORD-1]};
+    local cmd=${COMP_WORDS[COMP_CWORD - 1]};
     case $cmd in
     'dde-dconfig')
-        COMPREPLY=( $(compgen -W '--help --list --set --get --gui' -- $cur) ) ;;
+        COMPREPLY=( $(compgen -W 'help list set get gui watch' -- $cur) ) ;;
+    'list')
+        local result=( $(dde-dconfig list) )
+        COMPREPLY=( $(compgen -W "${result[*]}" -- $cur) ) ;;
+    'get')
+        local result=( $(dde-dconfig list) )
+        COMPREPLY=( $(compgen -W "${result[*]}" -- $cur) ) ;;
+    'set')
+        local result=( $(dde-dconfig list) )
+        COMPREPLY=( $(compgen -W "${result[*]}" -- $cur) ) ;;
+    'reset')
+        local result=( $(dde-dconfig list) )
+        COMPREPLY=( $(compgen -W "${result[*]}" -- $cur) ) ;;
+    'watch')
+        local result=( $(dde-dconfig list) )
+        COMPREPLY=( $(compgen -W "${result[*]}" -- $cur) ) ;;
     '-a')
-        local result=( $(dde-dconfig --list) )
+        local result=( $(dde-dconfig list) )
         COMPREPLY=( $(compgen -W "${result[*]}" -- $cur) ) ;;
     '-r')
-        local a=${COMP_WORDS[COMP_CWORD-2]}
-        local result=( $(dde-dconfig --list -a $a) )
+        local a=${COMP_WORDS[COMP_CWORD - 2]}
+        local result=( $(dde-dconfig list -a $a) )
         COMPREPLY=( $(compgen -W "${result[*]}" -- $cur) ) ;;
     '-k')
         local a=${COMP_WORDS[COMP_CWORD-4]}

--- a/dconfig-center/example/dde-dconfig.sh
+++ b/dconfig-center/example/dde-dconfig.sh
@@ -9,48 +9,48 @@
 # user cache is in the position. e.g: /home/userhome/.config/dsg/configs/dconfig-example/example.json
 
 # list all appid.
-dde-dconfig --list
+dde-dconfig list
 
 # list all resource for the appid.
-dde-dconfig --list -a=dconfig-example
+dde-dconfig list dconfig-example
 
 # list all matched common resource.
-dde-dconfig --list -r=""
+dde-dconfig list -r=""
 
 #list all subpath for the resource.
-dde-dconfig --list -a=dconfig-example -r=example
+dde-dconfig list dconfig-example -r=example
 
 
 # query all method for `-m` argument.
-dde-dconfig --get
+dde-dconfig get
 
 # query all keys for the resource, which `subpath` is '/a'.
-dde-dconfig --get -a=dconfig-example -r=example -s=/a
+dde-dconfig get dconfig-example -r=example -s=/a
 
 # query name for the key, which `language` is 'zh_CN'.
-dde-dconfig --get -a=dconfig-example -r=example -m=name -k=canExit -l=zh_CN
+dde-dconfig get dconfig-example -r=example -m=name canExit -l=zh_CN
 
 # query description for the key.
-dde-dconfig --get -a=dconfig-example -r=example -m=description -k=canExit
+dde-dconfig get dconfig-example -r=example -m=description canExit
 
 # query visibility for the key.
-dde-dconfig --get -a=dconfig-example -r=example -m=visibility -k=canExit
+dde-dconfig get dconfig-example -r=example -m=visibility canExit
 
 # query permissions for the key.
-dde-dconfig --get -a=dconfig-example -r=example -m=permissions -k=canExit
+dde-dconfig get dconfig-example -r=example -m=permissions canExit
 
 
 # set value for the key.
-dde-dconfig --set -a=dconfig-example -r=example -k=canExit -v=false
+dde-dconfig set dconfig-example -r=example canExit -v=false
 # set value for the key, which data type is array and value is json format.
-dde-dconfig --set -a dconfig-example -r=example -k=array -v="[ \"value1\", \"value2\" ]"
+dde-dconfig set dconfig-example -r=example array -v="[ \"value1\", \"value2\" ]"
 # set value for the key, which data type is map and value is json format.
-dde-dconfig --set -a dconfig-example -r=example -k=map -v="{ \"key1\": \"value1\", \"key2\": \"value2\" }"
+dde-dconfig set dconfig-example -r=example map -v="{ \"key1\": \"value1\", \"key2\": \"value2\" }"
 
 # reset value for the key.
-dde-dconfig --reset -a=dconfig-example -r=example -k=canExit
+dde-dconfig reset dconfig-example -r=example canExit
 
 # query value for the key
-dde-dconfig --get -a=dconfig-example -r=example -k=canExit
+dde-dconfig get dconfig-example -r=example canExit
 # query value for the key, which data type is array and value is json format.
-dde-dconfig --get -a=dconfig-example -r=example -k=array
+dde-dconfig get dconfig-example -r=example array


### PR DESCRIPTION
  Support positional argument for dde-dconfig.
  resourceid's value falling back to appid if `-r` is empty.
  Add some help information.
  Modify commander's struct, using class instead of function.