### PR TITLE
chore: Can't find QCommandLineParser

### DIFF
--- a/dconfig-center/dde-dconfig-daemon/main.cpp
+++ b/dconfig-center/dde-dconfig-daemon/main.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
 #include <QCoreApplication>
+#include <QCommandLineParser>
 #include <QDebug>
 #include <DLog>
 


### PR DESCRIPTION
  Including header file.