### PR TITLE
feat: Sync setValue for dde-dconfig-editor

### DIFF
--- a/dconfig-center/dde-dconfig-editor/mainwindow.h
+++ b/dconfig-center/dde-dconfig-editor/mainwindow.h
@@ -36,6 +36,7 @@ public:
     KeyContent(const QString &key, QWidget *parent = nullptr);
     void setBaseInfo(ConfigGetter *getter, const QString &language);
     QString key() const;
+    void updateContent(ConfigGetter *getter);
 
 private Q_SLOTS:
     void onDoubleValueChanged(double value);


### PR DESCRIPTION
  Sync value from ConfigGetter to UI when setValue.
  Fallback displayName and description to default language.
  Only refresh the item's content when reset.