### PR TITLE
fix: repeated items for dde-dconfig-editor

### DIFF
--- a/dconfig-center/dde-dconfig-editor/mainwindow.cpp
+++ b/dconfig-center/dde-dconfig-editor/mainwindow.cpp
@@ -221,6 +221,7 @@ void MainWindow::refreshAppResources(const QString &appid, const QString &matchR
 {
     resourceListView->reset();
     auto model = qobject_cast<QStandardItemModel *>(resourceListView->model());
+    model->clear();
 
     const auto &resources = appid == NoAppId ? ResourceList() : resourcesForApp(appid);
 


### PR DESCRIPTION
  model need clear when refresh app resources.
  it introduced in 6c737db9e9661d158a1c7267424004cf47763b59
