### PR TITLE
fix: The item of OEM is readonly by permission field

### DIFF
--- a/dconfig-center/common/helper.hpp
+++ b/dconfig-center/common/helper.hpp
@@ -31,6 +31,8 @@ constexpr int SubpathRole = Qt::UserRole + 13;
 constexpr int KeyRole = Qt::UserRole + 14;
 constexpr int ValueRole = Qt::UserRole + 15;
 constexpr int DescriptionRole = Qt::UserRole + 16;
+constexpr int FlagsRole = Qt::UserRole + 17;
+
 static const QString NoAppId;
 static const QString VirtualAppName("virtual-generic-applicaiton");
 

--- a/dconfig-center/common/valuehandler.cpp
+++ b/dconfig-center/common/valuehandler.cpp
@@ -83,6 +83,11 @@ public:
         return manager->version();
     }
 
+    int flags(const QString &key) const override
+    {
+        return manager->flags(key);
+    }
+
     void release() override
     {
         manager->release();
@@ -206,6 +211,11 @@ public:
     {
         const auto ver = manager->meta()->version();
         return QString("%1.%2").arg(ver.major).arg(ver.minor);
+    }
+
+    int flags(const QString &key) const override
+    {
+        return manager->meta()->flags(key);
     }
 
     void release() override

--- a/dconfig-center/common/valuehandler.h
+++ b/dconfig-center/common/valuehandler.h
@@ -21,6 +21,7 @@ public:
     virtual QString displayName(const QString &key, const QString &locale) = 0;
     virtual QString description(const QString &key, const QString &locale) = 0;
     virtual QString version() const = 0;
+    virtual int flags(const QString &key) const = 0;
 
     virtual void release() = 0;
     virtual bool isDefaultValue(const QString &key) = 0;

--- a/dconfig-center/dde-dconfig-editor/oemdialog.cpp
+++ b/dconfig-center/dde-dconfig-editor/oemdialog.cpp
@@ -86,6 +86,7 @@ void OEMDialog::loadData(const QString &language)
 
                 QVariant value =  manager.get()->value(key);
                 QVariant description = manager.get()->description(key, language);
+                QVariant flags = manager.get()->flags(key);
                 auto valueItem = new DStandardItem();
                 valueItem->setSizeHint(QSize(200, 45));
                 valueItem->setData(app, AppidRole);
@@ -94,6 +95,7 @@ void OEMDialog::loadData(const QString &language)
                 valueItem->setData(key, KeyRole);
                 valueItem->setData(value, ValueRole);
                 valueItem->setData(description, DescriptionRole);
+                valueItem->setData(flags, FlagsRole);
                 resourceItem->appendRow(QList<QStandardItem*>() << keyItem << valueItem);
                 m_exportView->setIndexWidget(valueItem->index(), getItemWidget(manager.get(), valueItem));
             }
@@ -120,12 +122,14 @@ void OEMDialog::loadData(const QString &language)
                     QVariant value =  manager.get()->value(key);
                     QVariant description = manager.get()->description(key, language);
                     auto valueItem = new DStandardItem(value.toString());
+                    QVariant flags = manager.get()->flags(key);
                     valueItem->setData(app, AppidRole);
                     valueItem->setData(resource, ResourceRole);
                     valueItem->setData(subpath, SubpathRole);
                     valueItem->setData(key, KeyRole);
                     valueItem->setData(value, ValueRole);
                     valueItem->setData(description, DescriptionRole);
+                    valueItem->setData(flags, FlagsRole);
 
                     subpathItem->appendRow(QList<QStandardItem*>() << keyItem << valueItem);
                     m_exportView->setIndexWidget(valueItem->index(), getItemWidget(manager.get(), valueItem));
@@ -339,8 +343,8 @@ void OEMDialog::createJsonFile(const QString &fileName, const QList<DStandardIte
 
 QWidget *OEMDialog::getItemWidget(ConfigGetter *getter, DStandardItem *item)
 {
-    const QString &permissions = getter->permissions(item->data(KeyRole).toString());
-    bool canWrite = permissions == "readwrite" ? true : false;
+    const int flags = getter->flags(item->data(KeyRole).toString());
+    bool canWrite = !(flags & Dtk::Core::DConfigFile::Flag::NoOverride);
     QVariant v = item->data(ValueRole);
     QWidget *valueWidget = nullptr;
     if (v.type() == QVariant::Bool) {

--- a/dconfig-center/example/configs/example.json
+++ b/dconfig-center/example/configs/example.json
@@ -12,6 +12,16 @@
             "permissions": "readwrite",
             "visibility": "private"
         },
+        "readOnlyKey": {
+            "value": true,
+            "serial": 0,
+            "flags": ["global"],
+            "name": "I am name",
+            "name[zh_CN]": "我是名字",
+            "description": "I am description",
+            "permissions": "readonly",
+            "visibility": "private"
+        },
         "key2": {
             "value": "125",
             "serial": 0,


### PR DESCRIPTION
It should be decided if the item of OEM is readonly by the flags [nooverride]

Log: fix the item of OEM is readonly by permission field