### PR TITLE
feat: support to read other user's config for editor

### DIFF
--- a/dconfig-center/common/helper.hpp
+++ b/dconfig-center/common/helper.hpp
@@ -23,6 +23,7 @@ using SubpathKey = QString;
 using ResourceList = QList<ResourceId>;
 using AppList = QList<AppId>;
 using SubpathList = QList<SubpathKey>;
+using UserInfo = QPair<QString, int>;
 
 static const QString &SUFFIX = QString(".json");
 constexpr int ConfigUserRole = Qt::UserRole + 10;
@@ -239,4 +240,25 @@ static void loadTranslation(const QString &fileName)
             break;
         }
     }
+}
+
+static QList<UserInfo> fetchUserInfos()
+{
+    QList<UserInfo> res;
+    QFile file("/etc/passwd");
+    if (!file.open(QIODevice::ReadOnly)) {
+        return {};
+    }
+    while (!file.atEnd()) {
+        QByteArray line = file.readLine();
+        const auto user = line.split(':');
+        if (user.count() != 7)
+            continue;
+        const auto loginin = user.at(6);
+        if (loginin.contains("nologin"))
+            continue;
+
+        res << UserInfo{user[0], user[2].toInt()};
+    }
+    return res;
 }

--- a/dconfig-center/common/valuehandler.cpp
+++ b/dconfig-center/common/valuehandler.cpp
@@ -288,6 +288,20 @@ ValueHandler::~ValueHandler()
 {
 }
 
+static int g_currentUid = -1;
+void ValueHandler::setCurrentUid(int uid)
+{
+    g_currentUid = uid;
+}
+
+int ValueHandler::currentUid()
+{
+    if (g_currentUid == -1) {
+        g_currentUid = getuid();
+    }
+    return g_currentUid;
+}
+
 ConfigGetter* ValueHandler::createManager()
 {
     if (DBusHandler::isServiceRegistered() || DBusHandler::isServiceActivatable()) {
@@ -308,6 +322,8 @@ ConfigGetter* ValueHandler::createManager()
 
 int ValueHandler::getUid() const
 {
+    if (uid == -1)
+        return currentUid();
     return uid;
 }
 

--- a/dconfig-center/common/valuehandler.h
+++ b/dconfig-center/common/valuehandler.h
@@ -34,6 +34,8 @@ public:
     explicit ValueHandler(const QString &appid, const QString &fileName, const QString &subpath);
     explicit ValueHandler(int uid, const QString &appid, const QString &fileName, const QString &subpath);
     ~ValueHandler();
+    static void setCurrentUid(int uid);
+    static int currentUid();
 
     ConfigGetter *createManager();
     int getUid() const;

--- a/dconfig-center/dde-dconfig-editor/mainwindow.cpp
+++ b/dconfig-center/dde-dconfig-editor/mainwindow.cpp
@@ -352,6 +352,26 @@ void MainWindow::installTranslate()
     connect(contentView, &Content::languageChanged, this, [this](){
         emit resourceListView->clicked(resourceListView->currentIndex());
     });
+    const auto userInfos = fetchUserInfos();
+    if (!userInfos.isEmpty()) {
+        auto userMenu = titlebar->menu()->addMenu(tr("Switch User"));
+        QActionGroup *userGroup = new QActionGroup(this);
+        for (const auto user : userInfos) {
+            const auto uid = user.second;
+            auto action = userMenu->addAction(user.first);
+            action->setProperty("uid", uid);
+            action->setCheckable(true);
+            if (ValueHandler::currentUid() == uid) {
+                action->setChecked(true);
+            }
+            userGroup->addAction(action);
+        }
+        connect(userGroup, &QActionGroup::triggered, this, [this] (QAction *action) {
+            const auto uid = action->property("uid").toInt();
+            qDebug() << "Switch to the user" << action->text() << ", uid:" << uid;
+            ValueHandler::setCurrentUid(uid);
+        });
+    }
 
     const auto systemLanguage = QLocale::system().name();
     qDebug() << systemLanguage;

--- a/dconfig-center/dde-dconfig-editor/translates/dde-dconfig-editor_zh_CN.ts
+++ b/dconfig-center/dde-dconfig-editor/translates/dde-dconfig-editor_zh_CN.ts
@@ -144,6 +144,11 @@
         <source>english</source>
         <translation>英文</translation>
     </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="357"/>
+        <source>Switch User</source>
+        <translation>切换用户</translation>
+    </message>
 </context>
 <context>
     <name>OEMDialog</name>


### PR DESCRIPTION
We can run dde-dconfig-editor as user A, and read user B's config,
It's only work for config flags contains UserPublic,
some config maybe not read because of permission.
If we want to read user B's config as user B, we only runn
dde-dconfig-editor by user B.
