### PR TITLE
fix: incorrect override format for json when export to OEM

### DIFF
--- a/dconfig-center/common/helper.hpp
+++ b/dconfig-center/common/helper.hpp
@@ -212,6 +212,12 @@ static QString qvariantToString(const QVariant &v)
     return doc.isNull() ? v.toString() : doc.toJson();
 }
 
+static QString qvariantToStringCompact(const QVariant &v)
+{
+    const auto &doc = QJsonDocument::fromVariant(v);
+    return doc.isNull() ? v.toString() : doc.toJson(QJsonDocument::Compact);
+}
+
 static QVariant stringToQVariant(const QString &s)
 {
     QJsonParseError error;


### PR DESCRIPTION
translate value to json string.
escape csv field.

## Summary by Sourcery

Fixes an issue where JSON values were not correctly formatted when exporting to OEM, and also escapes CSV fields to ensure proper handling of commas, quotes, and newlines.

Bug Fixes:
- Fixes incorrect JSON formatting when exporting to OEM.
- Escapes CSV fields to handle commas, quotes, and newlines correctly.