### PR TITLE
feat: adapt to dtk6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ cmake_minimum_required(VERSION 3.7)
 set(DVERSION "1.0.0" CACHE STRING "define project version")
 add_definitions(-DVERSION="${DVERSION}")
 
-set(DTK_VERSION "5" CACHE STRING "Dtk Version")
+set(DTK_VERSION "6" CACHE STRING "Dtk Version")
 
 if (DTK_VERSION STREQUAL "5")
     set(QT_VERSION_MAJOR "5")

--- a/dconfig-center/common/helper.hpp
+++ b/dconfig-center/common/helper.hpp
@@ -231,7 +231,7 @@ static QStringList translationDirs()
 {
     QStringList result;
     result << QCoreApplication::applicationDirPath();
-    for (auto item : Dtk::Core::DStandardPaths::standardLocations(QStandardPaths::DataLocation)) {
+    for (auto item : Dtk::Core::DStandardPaths::standardLocations(QStandardPaths::AppLocalDataLocation)) {
         result << item + "/translations";
     };
     return result;

--- a/dconfig-center/dde-dconfig-daemon/src.cmake
+++ b/dconfig-center/dde-dconfig-daemon/src.cmake
@@ -2,8 +2,6 @@
 #
 # SPDX-License-Identifier: LGPL-3.0-only
 
-find_package(Qt5DBus REQUIRED)
-
 if(EnableDtk5)
 qt5_add_dbus_adaptor(DCONFIG_DBUS_XML ../dde-dconfig-daemon/services/org.desktopspec.ConfigManager.xml
     dconfigserver.h DSGConfigServer

--- a/dconfig-center/dde-dconfig-editor/oemdialog.cpp
+++ b/dconfig-center/dde-dconfig-editor/oemdialog.cpp
@@ -212,7 +212,6 @@ void OEMDialog::saveCSVFile(const QString &dirName)
     QFile file(fileName);
     if (file.open(QIODevice::WriteOnly | QIODevice::Text)) {
         QTextStream out(&file);
-        out.setCodec("UTF-8");
         out << "appid," << "resource," << "key," << "value," << "path" << "\n";
         for (auto items : m_overrides) {
             for (auto item : items) {
@@ -357,7 +356,12 @@ QWidget *OEMDialog::getItemWidget(ConfigGetter *getter, DStandardItem *item)
     bool canWrite = !(flags & Dtk::Core::DConfigFile::Flag::NoOverride);
     QVariant v = item->data(ValueRole);
     QWidget *valueWidget = nullptr;
-    if (v.type() == QVariant::Bool) {
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    const auto valueType = v.type();
+#else
+    const auto valueType = v.typeId();
+#endif
+    if (valueType == QVariant::Bool) {
         auto btn = new DSwitchButton();
         btn->setChecked(v.toBool());
         btn->setEnabled(canWrite);
@@ -373,7 +377,7 @@ QWidget *OEMDialog::getItemWidget(ConfigGetter *getter, DStandardItem *item)
         hlayout->addWidget(btn);
 
         valueWidget = widget;
-    } else if (v.type() == QVariant::Double) {
+    } else if (valueType == QVariant::Double) {
         auto widget = new DDoubleSpinBox();
         widget->setRange(std::numeric_limits<double>::min(), std::numeric_limits<double>::max());
         widget->setValue(v.toDouble());

--- a/dconfig-center/example/CMakeLists.txt
+++ b/dconfig-center/example/CMakeLists.txt
@@ -13,14 +13,14 @@ ADD_EXECUTABLE(dconfig-example ./main.cpp)
 
 target_link_libraries(${PROJECT_NAME} PUBLIC Qt${QT_VERSION_MAJOR}::Core Dtk${DTK_VERSION_MAJOR}::Core)
 
-dconfig_meta_files(APPID dconfig-example BASE ./configs FILES ./configs/a/example.json)
+dtk_add_config_meta_files(APPID dconfig-example BASE ./configs FILES ./configs/a/example.json)
 
-dconfig_meta_files(COMMONID true FILES ./configs/example.json ./configs/a/example.json)
+dtk_add_config_meta_files(COMMONID true FILES ./configs/example.json ./configs/a/example.json)
 
-dconfig_meta_files(APPID dconfig-example FILES ./configs/example.json)
+dtk_add_config_meta_files(APPID dconfig-example FILES ./configs/example.json)
 
-dconfig_override_files(APPID dconfig-example BASE ./configs META_NAME example  FILES ./configs/dconf-example.override.json ./configs/a/dconf-example.override.a.json)
+dtk_add_config_override_files(APPID dconfig-example BASE ./configs META_NAME example  FILES ./configs/dconf-example.override.json ./configs/a/dconf-example.override.a.json)
 
-dconfig_override_files(APPID dconfig-example  META_NAME example  FILES ./configs/dconf-example.override.json ./configs/a/dconf-example.override.a.json)
+dtk_add_config_override_files(APPID dconfig-example  META_NAME example  FILES ./configs/dconf-example.override.json ./configs/a/dconf-example.override.a.json)
 
 

--- a/debian/control
+++ b/debian/control
@@ -6,15 +6,15 @@ Build-Depends:
  debhelper (>=9),
  pkg-config,
  cmake,
- qtbase5-dev,
+ qt6-base-dev,
  libdtkcommon-dev,
- libdtkcore-dev(>=5.6.19),
- libdtkgui-dev,
- libdtkwidget-dev,
+ libdtk6core-dev,
+ libdtk6gui-dev,
+ libdtk6widget-dev,
  libgtest-dev,
  doxygen,
- qttools5-dev-tools,
- qttools5-dev
+ qt6-tools-dev-tools,
+ qt6-tools-dev
 Standards-Version: 4.3.0
 
 Package: dde-dconfig-daemon

--- a/debian/dde-dconfig-doc.install
+++ b/debian/dde-dconfig-doc.install
@@ -1,1 +1,1 @@
-usr/share/qt5/doc/dde-dconfig-doc.qch
+usr/share/qt6/doc/dde-dconfig-doc.qch

--- a/debian/rules
+++ b/debian/rules
@@ -1,13 +1,12 @@
 #!/usr/bin/make -f
 DPKG_EXPORT_BUILDFLAGS = 1
 include /usr/share/dpkg/default.mk
-export QT_SELECT = qt5
 
 %:
 	dh $@ --parallel
 
 override_dh_auto_configure:
-	dh_auto_configure -- -DDVERSION=$(DEB_VERSION_UPSTREAM) -DDTK_VERSION=5
+	dh_auto_configure -- -DDVERSION=$(DEB_VERSION_UPSTREAM) -DDTK_VERSION=6
 
 
 override_dh_auto_install:


### PR DESCRIPTION
- feat: adapt to dtk6
- refact: switch to qt6 for debian

## Summary by Sourcery

Adapt the project to DTK6 and switch to Qt6 for Debian, including updating CMake functions and adjusting file locations.

Enhancements:
- Update CMake functions to use dtk_add_config_meta_files and dtk_add_config_override_files.
- Adjust file locations to be compatible with DTK6.
- Update code to be compatible with Qt6, including changes to QVariant type checking.
- Remove unnecessary codec setting for QTextStream.