### PR TITLE
refact: 更新服务文件使用 deepin-daemon 用户替代 dde-dconfig-daemon

### DIFF
--- a/dconfig-center/dde-dconfig-daemon/CMakeLists.txt
+++ b/dconfig-center/dde-dconfig-daemon/CMakeLists.txt
@@ -48,8 +48,5 @@ install (FILES services/org.desktopspec.ConfigManager.conf DESTINATION ${CMAKE_I
 install(FILES services/org.desktopspec.ConfigManager.service DESTINATION ${CMAKE_INSTALL_DATADIR}/dbus-1/system-services)
 install(FILES services/dde-dconfig-daemon.service DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/systemd/system)
 
-## sysusers file
-install (FILES services/dde-dconfig-daemon.conf DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/sysusers.d)
-
 ## bin
 install(TARGETS dde-dconfig-daemon DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/dconfig-center/dde-dconfig-daemon/main.cpp
+++ b/dconfig-center/dde-dconfig-daemon/main.cpp
@@ -31,6 +31,7 @@ int main(int argc, char *argv[])
 
     QCoreApplication a(argc, argv);
     a.setOrganizationName("deepin");
+    a.setApplicationName("dde-dconfig-daemon");
 
     QCommandLineParser parser;
     parser.addHelpOption();
@@ -69,6 +70,18 @@ int main(int argc, char *argv[])
 
     // Initialization of DtkCore needs to be later than `registerService` avoid earlier request itself.
     Dtk::Core::DLogManager::registerConsoleAppender();
+    const char *logsDirectory("LOGS_DIRECTORY");
+    if (!qEnvironmentVariableIsEmpty(logsDirectory)) {
+        const QString path(qEnvironmentVariable(logsDirectory));
+        const auto logPath(QString("%1/%2/%2.log").arg(path).arg(a.applicationName()));
+        const QFileInfo file(logPath);
+        if (!file.exists()) {
+            if (!QDir().mkpath(file.absoluteDir().path())) {
+                qWarning() << "Failed to create log path." << file.absoluteFilePath();
+            }
+        }
+        Dtk::Core::DLogManager::setlogFilePath(logPath);
+    }
     Dtk::Core::DLogManager::registerFileAppender();
     qInfo() << "Log path is:" << Dtk::Core::DLogManager::getlogFilePath();
     QObject::connect(qApp, &QCoreApplication::aboutToQuit, [&dsgConfig]() {

--- a/dconfig-center/dde-dconfig-daemon/services/dde-dconfig-daemon.conf
+++ b/dconfig-center/dde-dconfig-daemon/services/dde-dconfig-daemon.conf
@@ -1,8 +1,0 @@
-#  This file is part of systemd.
-#
-#  systemd is free software; you can redistribute it and/or modify it
-#  under the terms of the GNU Lesser General Public License as published by
-#  the Free Software Foundation; either version 2.1 of the License, or
-#  (at your option) any later version.
-
-u dde-dconfig-daemon - "dde-dconfig-daemon user" /var/lib/dde-dconfig-daemon /usr/sbin/nologin

--- a/dconfig-center/dde-dconfig-daemon/services/dde-dconfig-daemon.service
+++ b/dconfig-center/dde-dconfig-daemon/services/dde-dconfig-daemon.service
@@ -7,15 +7,16 @@ After=dbus.socket
 
 [Service]
 Type=dbus
-User=dde-dconfig-daemon
+User=deepin-daemon
 BusName=org.desktopspec.ConfigManager
 ExecStart=/usr/bin/dde-dconfig-daemon
 Environment=DSG_DATA_DIRS=/usr/share/dsg:/var/lib/linglong/entries/share/dsg
 
-ReadOnlyPaths=/usr/share/dsg -/persistent/linglong/entries/share/dsg
+ReadOnlyPaths=/usr/share/dsg -/var/lib/linglong/entries/share/dsg
 
 StateDirectory=dde-dconfig-daemon
 StateDirectoryMode=0700
+LogsDirectory=deepin
 
 DevicePolicy=closed
 

--- a/dconfig-center/dde-dconfig-daemon/services/org.desktopspec.ConfigManager.conf
+++ b/dconfig-center/dde-dconfig-daemon/services/org.desktopspec.ConfigManager.conf
@@ -5,7 +5,7 @@
  "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
 <busconfig>
    <!-- Everybody is allowed to own the service on the D-Bus system bus -->
-  <policy user="dde-dconfig-daemon">
+  <policy user="deepin-daemon">
     <allow own="org.desktopspec.ConfigManager"/>
   </policy>
  <!-- Allow anyone to invoke methods on the interfaces -->

--- a/dconfig-center/dde-dconfig-daemon/services/org.desktopspec.ConfigManager.service
+++ b/dconfig-center/dde-dconfig-daemon/services/org.desktopspec.ConfigManager.service
@@ -1,5 +1,5 @@
 [D-BUS Service]
 Name=org.desktopspec.ConfigManager
 Exec=/usr/bin/dde-dconfig-daemon
-User=dde-dconfig-daemon
+User=deepin-daemon
 SystemdService=dde-dconfig-daemon.service

--- a/debian/dde-dconfig-daemon.sysusers
+++ b/debian/dde-dconfig-daemon.sysusers
@@ -1,8 +1,0 @@
-#  This file is part of systemd.
-#
-#  systemd is free software; you can redistribute it and/or modify it
-#  under the terms of the GNU Lesser General Public License as published by
-#  the Free Software Foundation; either version 2.1 of the License, or
-#  (at your option) any later version.
-
-u dde-dconfig-daemon - "dde-dconfig-daemon user" /var/lib/dde-dconfig-daemon /usr/sbin/nologin

--- a/debian/rules
+++ b/debian/rules
@@ -11,4 +11,3 @@ override_dh_auto_configure:
 
 override_dh_auto_install:
 	dh_auto_install
-	dh_installsysusers dde-dconfig-daemon.sysusers


### PR DESCRIPTION
- chore: remove sysusers configuration files
- feat: improve config and log management

## Summary by Sourcery

Improve configuration and log management by adding environment-variable-based path resolution, unify config handling, set application name for logging consistency, and clean up obsolete sysusers configs while updating D-Bus service policy user

New Features:
- Support STATE_DIRECTORY environment variable for configurable config prefix paths
- Introduce LOGS_DIRECTORY environment variable to configure log file path and auto-create log directories

Enhancements:
- Unify config and cache prefix path resolution via configPrefixPath helper
- Set QCoreApplication applicationName for consistent logging

Build:
- Remove sysusers configuration files and related installation rules from CMakeLists

Deployment:
- Change D-Bus policy user in org.desktopspec.ConfigManager.conf from dde-dconfig-daemon to deepin-daemon