### PR TITLE
fix: add input validation and update D-Bus permissions

### DIFF
--- a/dconfig-center/dde-dconfig-daemon/dconfigserver.cpp
+++ b/dconfig-center/dde-dconfig-daemon/dconfigserver.cpp
@@ -96,6 +96,13 @@ DSGConfigResource *DSGConfigServer::resourceObject(const GenericResourceKey &key
  */
 void DSGConfigServer::setDelayReleaseTime(const int ms)
 {
+    if (ms < 0) {
+        QString errorMsg = QString("Negative values are not supported for delayed release time.");
+        if (calledFromDBus())
+            sendErrorReply(QDBusError::InvalidArgs, errorMsg);
+        qCWarning(cfLog()) << qPrintable(errorMsg);
+        return;
+    }
     m_refManager->setDelayReleaseTime(ms);
 }
 

--- a/dconfig-center/dde-dconfig-daemon/services/org.desktopspec.ConfigManager.conf
+++ b/dconfig-center/dde-dconfig-daemon/services/org.desktopspec.ConfigManager.conf
@@ -7,16 +7,40 @@
    <!-- Everybody is allowed to own the service on the D-Bus system bus -->
   <policy user="deepin-daemon">
     <allow own="org.desktopspec.ConfigManager"/>
+    <allow send_destination="org.desktopspec.ConfigManager"/>
+    <allow receive_sender="org.desktopspec.ConfigManager"/>
+  </policy>
+  <policy user="root">
+    <allow send_destination="org.desktopspec.ConfigManager"/>
+    <allow receive_sender="org.desktopspec.ConfigManager"/>
   </policy>
  <!-- Allow anyone to invoke methods on the interfaces -->
   <policy context="default">
-    <allow own="org.desktopspec.ConfigManager"/>
-    <allow send_destination="org.desktopspec.ConfigManager"/>
+    <deny send_destination="org.desktopspec.ConfigManager"/>
 
+    <!-- Basic D-Bus API stuff -->
+    <allow send_destination="org.desktopspec.ConfigManager"
+           send_interface="org.freedesktop.DBus.Introspectable"/>
+    <allow send_destination="org.desktopspec.ConfigManager"
+           send_interface="org.freedesktop.DBus.Peer"/>
+    <allow send_destination="org.desktopspec.ConfigManager"
+           send_interface="org.freedesktop.DBus.Properties"/>
+    <allow send_destination="org.desktopspec.ConfigManager"
+           send_interface="org.freedesktop.DBus.ObjectManager"/>
+
+    <!-- allow to call member for org.desktopspec.ConfigManager -->
+    <allow send_destination="org.desktopspec.ConfigManager"
+           send_interface="org.desktopspec.ConfigManager"
+           send_member="acquireManager"/>
+    <allow send_destination="org.desktopspec.ConfigManager"
+           send_interface="org.desktopspec.ConfigManager"
+           send_member="acquireManagerV2"/>
+
+    <!-- allow to call all member for org.desktopspec.ConfigManager.Manager -->
     <allow send_destination="org.desktopspec.ConfigManager"
            send_interface="org.desktopspec.ConfigManager.Manager"/>
-    <allow send_destination="org.desktopspec.ConfigManager"
-	    send_interface="org.desktopspec.ConfigManager" />
 
+    <!-- allow to receive all signal for org.desktopspec.ConfigManager -->
+    <allow receive_sender="org.desktopspec.ConfigManager"/>
   </policy>
 </busconfig>


### PR DESCRIPTION
1. Added input validation in setDelayReleaseTime() to reject negative
values with proper error handling
2. Updated D-Bus configuration file to:
   - Restrict default user permissions while allowing specific
operations
   - Explicitly allow root and deepin-daemon users to interact with
the service
   - Define granular permissions for different D-Bus interfaces and
methods
3. Improved security by limiting access to sensitive operations while
maintaining necessary functionality

fix: 添加输入验证并更新 D-Bus 权限

1. 在 setDelayReleaseTime() 中添加输入验证，拒绝负值并返回错误提示
2. 更新 D-Bus 配置文件：
   - 限制默认用户权限同时允许特定操作
   - 明确允许 root 和 deepin-daemon 用户与服务交互
   - 为不同 D-Bus 接口和方法定义细粒度权限
3. 通过限制敏感操作访问提升安全性，同时保持必要功能

Issue: https://bugzilla.suse.com/show_bug.cgi?id=1211374

## Summary by Sourcery

Add input validation for negative delay values and tighten D-Bus permissions for the ConfigManager service

Enhancements:
- Reject negative values in setDelayReleaseTime and return a D-Bus error reply
- Restrict default D-Bus permissions and explicitly allow only root and deepin-daemon to interact with the service
- Define granular interface, method, and signal permissions for the org.desktopspec.ConfigManager D-Bus interfaces