### PR TITLE
fix: replace QStringList with QVariantList in test case

### DIFF
--- a/dconfig-center/tests/ut_dconfigconn.cpp
+++ b/dconfig-center/tests/ut_dconfigconn.cpp
@@ -151,8 +151,8 @@ TEST_F(ut_DConfigConn, value) {
     ASSERT_EQ(conn->value("map").variant().toMap(), map);
 
     QVariantMap mapArray;
-    mapArray.insert("key1", QStringList{"value1"});
-    mapArray.insert("key2", QStringList{"value2"});
+    mapArray.insert("key1", QVariantList{"value1"});
+    mapArray.insert("key2", QVariantList{"value2"});
     QVariantList arrayMap;
     arrayMap.append(map);
     ASSERT_EQ(conn->value("map_array").variant().toMap(), mapArray);


### PR DESCRIPTION
Changed QStringList to QVariantList when inserting values into mapArray
in the test case. This modification ensures type consistency with the
expected test behavior since the test later checks the map against a
variant conversion. QVariantList is more appropriate here as it better
matches the variant-based data handling used throughout the test.

fix: 在测试用例中用 QVariantList 替换 QStringList

将测试用例中 mapArray 插入值时使用的 QStringList 改为 QVariantList。这一
修改确保了与预期测试行为类型的一致性，因为测试后续会将映射与变体转换进行
比较。在此处使用 QVariantList 更为合适，因为它更符合整个测试中使用的基于
变体的数据处理方式。

## Summary by Sourcery

Tests:
- Replace QStringList with QVariantList when inserting values into mapArray in ut_DConfigConn test to align with variant-based comparisons.