### PR TITLE
refactor: simplify CMake version requirements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,9 +2,7 @@
 #
 # SPDX-License-Identifier: LGPL-3.0-only
 
-cmake_minimum_required(VERSION 3.10...3.27)
-
-cmake_policy(SET CMP0177 NEW)
+cmake_minimum_required(VERSION 3.10)
 
 set(DVERSION "1.0.0" CACHE STRING "define project version")
 add_definitions(-DVERSION="${DVERSION}")


### PR DESCRIPTION
1. Removed upper bound restriction on CMake version (3.10...3.27 → 3.10)
2. Removed explicit CMP0177 policy setting which is now default in newer
CMake
3. Maintains minimum version requirement while allowing newer CMake
versions
4. Makes build configuration more flexible for different environments

refactor: 简化 CMake 版本要求

1. 移除了 CMake 版本的上限限制 (从 3.10...3.27 改为 3.10)
2. 移除了显式的 CMP0177 策略设置，该策略在新版 CMake 中已是默认
3. 保持最低版本要求的同时允许使用更新的 CMake 版本
4. 使构建配置对不同环境更具灵活性

## Summary by Sourcery

Relax and simplify CMake version requirements to improve build flexibility

Enhancements:
- Allow use of newer CMake versions beyond the previous upper bound
- Improve build configuration flexibility across different environments

Build:
- Require CMake version ≥ 3.10 without an upper bound
- Remove explicit CMP0177 policy setting