### PR TITLE
feat: add user configuration cleanup functionality

### DIFF
--- a/dconfig-center/dde-dconfig-daemon/dconfig_global.h
+++ b/dconfig-center/dde-dconfig-daemon/dconfig_global.h
@@ -194,3 +194,23 @@ inline QString getUserNameByUid(const uint uid)
     return QString::number(uid);
 #endif
 }
+
+/*!
+ \brief 获取配置文件的基础路径
+ 优先使用STATE_DIRECTORY环境变量，否则使用XDG标准配置目录。
+ 使用静态缓存避免重复计算。
+ \return 配置文件基础路径
+ */
+inline QString configPrefixPath()
+{
+    static QString path;
+    if (path.isEmpty()) {
+        const char *stateDirectory("STATE_DIRECTORY");
+        if (!qEnvironmentVariableIsEmpty(stateDirectory)) {
+            path = QString("%1/.config").arg(qEnvironmentVariable(stateDirectory));
+        } else {
+            path = Dtk::Core::DStandardPaths::path(Dtk::Core::DStandardPaths::XDG::ConfigHome);
+        }
+    }
+    return path;
+}

--- a/dconfig-center/dde-dconfig-daemon/dconfigresource.cpp
+++ b/dconfig-center/dde-dconfig-daemon/dconfigresource.cpp
@@ -17,20 +17,6 @@
 Q_DECLARE_LOGGING_CATEGORY(cfLog);
 DCORE_USE_NAMESPACE
 
-static QString configPrefixPath()
-{
-    static QString path;
-    if (path.isEmpty()) {
-        const char *stateDirectory("STATE_DIRECTORY");
-        if (!qEnvironmentVariableIsEmpty(stateDirectory)) {
-            path = QString("%1/.config").arg(qEnvironmentVariable(stateDirectory));
-        } else {
-            path = DStandardPaths::path(DStandardPaths::XDG::ConfigHome);
-        }
-        qInfo(cfLog) << "Config's prefix path is:" << path;
-    }
-    return path;
-}
 
 DSGConfigResource::DSGConfigResource(const QString &name, const QString &subpath, const QString &localPrefix, QObject *parent)
     : QObject (parent),
@@ -489,4 +475,23 @@ void DSGConfigResource::onGlobalValueChanged(const QString &key)
         const auto &resourceKey = getResourceKey(conn->key());
         doGlobalValueChanged(key, resourceKey);
     }
+}
+
+/*!
+ \brief 获取指定用户ID的所有连接
+ 遍历所有连接，返回属于指定用户的连接键列表
+ \a uid 用户ID
+ \return 属于该用户的连接键列表
+ */
+QList<ConnKey> DSGConfigResource::getConnectionsByUid(const uint uid) const
+{
+    QList<ConnKey> userConnections;
+    for (auto iter = m_conns.begin(); iter != m_conns.end(); ++iter) {
+        const ConnKey &connKey = iter.key();
+        const uint connUid = getConnectionKey(connKey);
+        if (connUid == uid) {
+            userConnections.append(connKey);
+        }
+    }
+    return userConnections;
 }

--- a/dconfig-center/dde-dconfig-daemon/dconfigresource.h
+++ b/dconfig-center/dde-dconfig-daemon/dconfigresource.h
@@ -56,6 +56,8 @@ public:
     void setSyncRequestCache(ConfigSyncRequestCache *cache);
     void doSyncConfigCache(const ConfigCacheKey &key);
 
+    QList<ConnKey> getConnectionsByUid(const uint uid) const;
+
 Q_SIGNALS:
     void releaseResource(const ConnServiceName &service);
     void releaseConn(const ConnServiceName &service, const ConnKey &connKey);

--- a/dconfig-center/dde-dconfig-daemon/dconfigserver.h
+++ b/dconfig-center/dde-dconfig-daemon/dconfigserver.h
@@ -60,6 +60,8 @@ public Q_SLOTS:
     void disableVerboseLogging();
     void setLogRules(const QString &rules);
 
+    void removeUserData(const uint &uid);
+
 private Q_SLOTS:
     void onReleaseChanged(const ConnServiceName &service, const ConnKey &connKey);
 

--- a/dconfig-center/dde-dconfig-daemon/services/org.desktopspec.ConfigManager.xml
+++ b/dconfig-center/dde-dconfig-daemon/services/org.desktopspec.ConfigManager.xml
@@ -31,4 +31,7 @@
     <method name='setLogRules'>
       <arg type='s' name='rules' direction='in'/>
     </method>
+    <method name='removeUserData'>
+      <arg type='u' name='uid' direction='in'/>
+    </method>
 </interface>

--- a/dconfig-center/tests/ut_dconfigserver.cpp
+++ b/dconfig-center/tests/ut_dconfigserver.cpp
@@ -35,12 +35,14 @@ protected:
         ASSERT_TRUE(QFile::copy(":/config/example.json", path));
         ASSERT_TRUE(QFile::copy(":/config/example.json", noAppIdConfigPath()));
         qputenv("DSG_CONFIG_CONNECTION_DISABLE_DBUS", "true");
+        qputenv("STATE_DIRECTORY", LocalPrefix);
         dsgDataDir.set("DSG_DATA_DIRS", "/usr/share/dsg");
     }
     static void TearDownTestCase() {
         QFile::remove(configPath());
         QFile::remove(noAppIdConfigPath());
         qunsetenv("DSG_CONFIG_CONNECTION_DISABLE_DBUS");
+        qunsetenv("STATE_DIRECTORY");
         QDir(LocalPrefix).removeRecursively();
         dsgDataDir.restore();
     }
@@ -195,4 +197,280 @@ TEST_F(ut_DConfigServer, acquireManagerGeneric) {
     auto conn = resource->getConn(VirtualInterAppId, TestUid);
     ASSERT_TRUE(conn);
     ASSERT_EQ(resource->connSize(), 2);
+}
+
+TEST_F(ut_DConfigServer, removeUserData) {
+    // 测试用户ID
+    const uint testUid1 = 1001;
+    const uint testUid2 = 1002;
+    
+    // 创建多个用户的连接
+    auto path1 = server->acquireManagerV2(testUid1, APP_ID, FILE_NAME, QString("")).path();
+    auto path2 = server->acquireManagerV2(testUid2, APP_ID, FILE_NAME, QString("")).path();
+    auto path3 = server->acquireManagerV2(TestUid, APP_ID, FILE_NAME, QString("")).path();
+    
+    // 验证初始状态
+    ASSERT_EQ(server->resourceSize(), 1);
+    auto resource = server->resourceObject(getGenericResourceKey(path1));
+    ASSERT_TRUE(resource);
+    ASSERT_EQ(resource->connSize(), 3); // 三个用户的连接
+    
+    // 验证所有连接都存在
+    auto conn1 = resource->getConn(APP_ID, testUid1);
+    auto conn2 = resource->getConn(APP_ID, testUid2);
+    auto conn3 = resource->getConn(APP_ID, TestUid);
+    ASSERT_TRUE(conn1);
+    ASSERT_TRUE(conn2);
+    ASSERT_TRUE(conn3);
+    
+    // 测试删除用户1的数据
+    server->removeUserData(testUid1);
+    
+    // 验证用户1的连接被删除
+    ASSERT_FALSE(resource->getConn(APP_ID, testUid1));
+    ASSERT_EQ(resource->connSize(), 2); // 剩余两个连接
+    
+    // 验证其他用户的连接不受影响
+    ASSERT_TRUE(resource->getConn(APP_ID, testUid2));
+    ASSERT_TRUE(resource->getConn(APP_ID, TestUid));
+    ASSERT_EQ(server->resourceSize(), 1); // 资源仍然存在
+    
+    // 测试删除用户2的数据
+    server->removeUserData(testUid2);
+    
+    // 验证用户2的连接被删除
+    ASSERT_FALSE(resource->getConn(APP_ID, testUid2));
+    ASSERT_EQ(resource->connSize(), 1); // 剩余一个连接
+    
+    // 验证剩余用户的连接不受影响
+    ASSERT_TRUE(resource->getConn(APP_ID, TestUid));
+    ASSERT_EQ(server->resourceSize(), 1); // 资源仍然存在
+    
+    // 测试删除最后一个用户的数据
+    server->removeUserData(TestUid);
+    
+    // 验证所有连接都被删除，资源也被清理
+    ASSERT_EQ(server->resourceSize(), 0); // 资源被删除
+}
+
+TEST_F(ut_DConfigServer, removeUserDataMultipleResources) {
+    // 测试删除用户数据时涉及多个资源的情况
+    const uint testUid = 1003;
+    
+    // 为同一用户创建多个资源的连接
+    auto path1 = server->acquireManagerV2(testUid, APP_ID, FILE_NAME, QString("")).path();
+    auto path2 = server->acquireManagerV2(testUid, "org.foo.appid2", FILE_NAME, QString("")).path();
+    
+    // 验证初始状态
+    int initialResourceCount = server->resourceSize();
+    ASSERT_GE(initialResourceCount, 1);
+    
+    // 创建其他用户的连接以验证不受影响
+    auto path3 = server->acquireManagerV2(TestUid, APP_ID, FILE_NAME, QString("")).path();
+    
+    // 删除目标用户的数据
+    server->removeUserData(testUid);
+    
+    // 验证目标用户的所有连接都被删除
+    auto resource1 = server->resourceObject(getGenericResourceKey(path1));
+    if (resource1) {
+        ASSERT_FALSE(resource1->getConn(APP_ID, testUid));
+    }
+    
+    // 验证其他用户的连接不受影响
+    auto resource3 = server->resourceObject(getGenericResourceKey(path3));
+    if (resource3) {
+        ASSERT_TRUE(resource3->getConn(APP_ID, TestUid));
+    }
+}
+
+TEST_F(ut_DConfigServer, removeUserDataEdgeCases) {
+    // 测试边界情况
+    
+    // 删除不存在的用户数据（不应该崩溃）
+    server->removeUserData(9999);
+    ASSERT_EQ(server->resourceSize(), 0);
+    
+    // 创建一个连接然后删除两次
+    const uint testUid = 1004;
+    server->acquireManagerV2(testUid, APP_ID, FILE_NAME, QString(""));
+    ASSERT_EQ(server->resourceSize(), 1);
+    
+    // 第一次删除
+    server->removeUserData(testUid);
+    ASSERT_EQ(server->resourceSize(), 0);
+    
+    // 第二次删除同一用户（不应该崩溃）
+    server->removeUserData(testUid);
+    ASSERT_EQ(server->resourceSize(), 0);
+    
+    // 删除用户ID为0的数据（TestUid）
+    server->acquireManagerV2(TestUid, APP_ID, FILE_NAME, QString(""));
+    ASSERT_EQ(server->resourceSize(), 1);
+    
+    server->removeUserData(TestUid);
+    ASSERT_EQ(server->resourceSize(), 0);
+}
+
+TEST_F(ut_DConfigServer, removeUserDataGenericConfig) {
+    // 测试删除用户数据对通用配置的影响
+    // 使用TestUid (0) 来创建连接，因为在测试环境中这是有效的用户ID
+    
+    // 创建普通应用的连接
+    auto path1 = server->acquireManagerV2(TestUid, APP_ID, FILE_NAME, QString("")).path();
+    // 创建通用配置的连接
+    auto path2 = server->acquireManagerV2(TestUid, NoAppId, FILE_NAME, QString("")).path();
+    
+    ASSERT_EQ(server->resourceSize(), 1);
+    auto resource = server->resourceObject(getGenericResourceKey(path1));
+    ASSERT_TRUE(resource);
+    ASSERT_EQ(resource->connSize(), 2);
+    
+    // 验证连接都存在  
+    ASSERT_TRUE(resource->getConn(APP_ID, TestUid));
+    ASSERT_TRUE(resource->getConn(VirtualInterAppId, TestUid));
+    
+    // 删除用户数据
+    server->removeUserData(TestUid);
+    
+    // 验证所有连接都被删除，资源被清理
+    ASSERT_EQ(server->resourceSize(), 0);
+}
+
+TEST_F(ut_DConfigServer, removeUserDataFiles) {
+    // 测试删除用户数据时缓存文件也被删除
+    // 通过重新访问配置验证：如果返回默认值，说明缓存文件被正确删除
+    const uint testUid1 = 1001;
+    const uint testUid2 = 1002;
+    
+    // 创建用户连接
+    auto path1 = server->acquireManagerV2(testUid1, APP_ID, FILE_NAME, QString("")).path();
+    auto path2 = server->acquireManagerV2(testUid2, APP_ID, FILE_NAME, QString("")).path();
+    
+    auto resource = server->resourceObject(getGenericResourceKey(path1));
+    ASSERT_TRUE(resource);
+    
+    // 获取连接并设置非默认值（默认值是true）
+    auto conn1 = resource->getConn(APP_ID, testUid1);
+    auto conn2 = resource->getConn(APP_ID, testUid2);
+    ASSERT_TRUE(conn1);
+    ASSERT_TRUE(conn2);
+    
+    // 设置非默认值：用户1设置为false，用户2设置为false
+    conn1->setValue("canExit", QDBusVariant{false});
+    conn2->setValue("canExit", QDBusVariant{false});
+    
+    // 验证设置成功
+    ASSERT_EQ(conn1->value("canExit").variant().toBool(), false);
+    ASSERT_EQ(conn2->value("canExit").variant().toBool(), false);
+    
+    // 保存缓存
+    resource->save();
+    
+    // 删除用户1的数据
+    server->removeUserData(testUid1);
+    
+    // 验证用户1的连接被删除
+    ASSERT_FALSE(resource->getConn(APP_ID, testUid1));
+    ASSERT_TRUE(resource->getConn(APP_ID, testUid2));
+    
+    // 重新为用户1创建连接，验证缓存文件是否被删除
+    auto newPath1 = server->acquireManagerV2(testUid1, APP_ID, FILE_NAME, QString("")).path();
+    auto newResource = server->resourceObject(getGenericResourceKey(newPath1));
+    ASSERT_TRUE(newResource);
+    
+    auto newConn1 = newResource->getConn(APP_ID, testUid1);
+    ASSERT_TRUE(newConn1);
+    
+    qWarning() << "*******" << configPrefixPath();
+    // 关键验证：如果缓存文件被正确删除，应该返回默认值(true)，而不是之前设置的false
+    ASSERT_EQ(newConn1->value("canExit").variant().toBool(), true) 
+        << "Cache file was not properly deleted - expected default value (true) but got cached value (false)";
+    
+    // 验证用户2的配置仍然是之前设置的值（证明删除操作的隔离性）
+    ASSERT_EQ(conn2->value("canExit").variant().toBool(), false) 
+        << "User2's cache should not be affected by removing User1's data";
+    
+    // 删除用户2的数据并验证
+    server->removeUserData(testUid2);
+    
+    // 重新为用户2创建连接，验证其缓存文件也被删除
+    auto newPath2 = server->acquireManagerV2(testUid2, APP_ID, FILE_NAME, QString("")).path();
+    auto newResource2 = server->resourceObject(getGenericResourceKey(newPath2));
+    ASSERT_TRUE(newResource2);
+    
+    auto newConn2 = newResource2->getConn(APP_ID, testUid2);
+    ASSERT_TRUE(newConn2);
+    
+    // 验证用户2的缓存文件也被删除
+    ASSERT_EQ(newConn2->value("canExit").variant().toBool(), true) 
+        << "User2's cache file was not properly deleted";
+}
+
+TEST_F(ut_DConfigServer, removeUserDataWithSubpath) {
+    // 测试带有子路径的配置删除
+    const uint testUid = 1006;
+    const QString subpath = "test/subdir";
+    
+    // 创建带有子路径的连接
+    auto path = server->acquireManagerV2(testUid, APP_ID, FILE_NAME, subpath).path();
+    
+    auto resource = server->resourceObject(getGenericResourceKey(path));
+    ASSERT_TRUE(resource);
+    
+    // 获取连接并设置配置值
+    auto conn = resource->getConn(APP_ID, testUid);
+    ASSERT_TRUE(conn);
+    
+    conn->setValue("canExit", QDBusVariant{true});
+    
+    // 验证初始状态
+    ASSERT_EQ(resource->connSize(), 1);
+    ASSERT_TRUE(resource->getConn(APP_ID, testUid));
+    ASSERT_EQ(server->resourceSize(), 1);
+    
+    // 删除用户数据
+    server->removeUserData(testUid);
+    
+    // 验证连接和资源被清理
+    ASSERT_EQ(server->resourceSize(), 0);
+}
+
+TEST_F(ut_DConfigServer, removeUserDataSimpleValidation) {
+    // 简单直接的验证：确保删除用户数据后，同一服务器实例中的新连接返回默认值
+    const uint testUid = TestUid;
+    
+    // 1. 创建连接并设置非默认值
+    auto path1 = server->acquireManagerV2(testUid, APP_ID, FILE_NAME, QString("")).path();
+    auto resource1 = server->resourceObject(getGenericResourceKey(path1));
+    ASSERT_TRUE(resource1);
+    
+    auto conn1 = resource1->getConn(APP_ID, testUid);
+    ASSERT_TRUE(conn1);
+    
+    // 验证默认值
+    ASSERT_EQ(conn1->value("canExit").variant().toBool(), true) << "Default value should be true";
+    
+    // 设置非默认值
+    conn1->setValue("canExit", QDBusVariant{false});
+    ASSERT_EQ(conn1->value("canExit").variant().toBool(), false) << "Value should be set to false";
+    resource1->save();
+    
+    // 2. 删除用户数据
+    server->removeUserData(testUid);
+    
+    // 验证连接被删除
+    ASSERT_FALSE(resource1->getConn(APP_ID, testUid));
+    
+    // 3. 在同一服务器实例中创建新连接
+    auto path2 = server->acquireManagerV2(testUid, APP_ID, FILE_NAME, QString("")).path();
+    auto resource2 = server->resourceObject(getGenericResourceKey(path2));
+    ASSERT_TRUE(resource2);
+    
+    auto conn2 = resource2->getConn(APP_ID, testUid);
+    ASSERT_TRUE(conn2);
+    
+    // 4. 验证新连接返回默认值（这证明缓存被正确清除）
+    ASSERT_EQ(conn2->value("canExit").variant().toBool(), true) 
+        << "New connection should return default value after removeUserData";
 }


### PR DESCRIPTION
1. Added removeUserData method to clean up user-specific configs
2. Implemented configPrefixPath helper function in global header
3. Added getConnectionsByUid to find all connections for a user
4. Updated D-Bus interface definition with new method
5. Added detailed documentation in Chinese manual
6. Includes recursive directory removal for user cache files

The changes enable proper cleanup of user configuration data when
accounts are deleted, preventing stale configs from accumulating. The
implementation handles both in-memory connections and on-disk cache
files while maintaining security through D-Bus policy controls.

feat: 添加用户配置清理功能

1. 添加removeUserData方法清理用户特定配置
2. 在全局头文件中实现configPrefixPath辅助函数
3. 添加getConnectionsByUid查找用户所有连接
4. 更新D-Bus接口定义添加新方法
5. 在中文手册中添加详细文档
6. 包含用户缓存文件的递归目录删除

这些变更使得在删除账户时能够正确清理用户配置数据，防止残留配置积累。实现
同时处理内存中的连接和磁盘上的缓存文件，并通过D-Bus策略控制保持安全性。
