### PR TITLE
chore: bump version to 1.0.31

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-app-services (1.0.31) unstable; urgency=medium
+
+  * feat: add user configuration cleanup functionality
+  * refactor: simplify CMake version requirements
+
+ -- YeShanShan <yeshanshan@uniontech.com>  Thu, 19 Jun 2025 10:13:52 +0800
+
 dde-app-services (1.0.30) unstable; urgency=medium
 
   * chore(CI): add debian check workflow


### PR DESCRIPTION
update changelog to 1.0.31

## Summary by Sourcery

Chores:
- Bump Debian package version to 1.0.31 in changelog