### PR TITLE
feat: add Debian trigger integration for config updates

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -52,3 +52,8 @@ License: CC0-1.0
 Files: *.ts .tx/*
 Copyright: None
 License: CC0-1.0
+
+# scripts
+Files: dconfig-center/dde-dconfig-daemon/scripts/*
+Copyright: None
+License: CC0-1.0

--- a/dconfig-center/dde-dconfig-daemon/CMakeLists.txt
+++ b/dconfig-center/dde-dconfig-daemon/CMakeLists.txt
@@ -5,6 +5,8 @@
 find_package(Qt${QT_VERSION_MAJOR} ${REQUIRED_QT_VERSION} REQUIRED COMPONENTS Core DBus)
 find_package(Dtk${DTK_VERSION_MAJOR}Core REQUIRED)
 
+option(INSTALL_DEBIAN_TRIGGER "Install dconfig trigger handler script" OFF)
+
 # generate moc_predefs.h
 set(CMAKE_AUTOMOC ON)
 set(AUTOMOC_COMPILER_PREDEFINES ON)
@@ -42,3 +44,8 @@ install(FILES services/dde-dconfig-daemon.service DESTINATION ${CMAKE_INSTALL_PR
 
 ## bin
 install(TARGETS dde-dconfig-daemon DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+## trigger handler scripts
+if(INSTALL_DEBIAN_TRIGGER)
+    install(PROGRAMS scripts/dconfig-trigger-handler DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/dde-dconfig-daemon)
+endif()

--- a/dconfig-center/dde-dconfig-daemon/scripts/dconfig-trigger-handler
+++ b/dconfig-center/dde-dconfig-daemon/scripts/dconfig-trigger-handler
@@ -1,0 +1,160 @@
+#!/bin/bash
+# dconfig-trigger-handler - Handle configuration file changes via D-Bus update calls
+# This script is called when Debian triggers detect changes in configuration directories
+
+set -e
+
+# Configuration directories to monitor
+CONFIG_DIRS=(
+    "/usr/share/dsg/configs"
+    "/etc/dsg/configs"
+    "/var/lib/linglong/entries/share/dsg/configs"
+)
+
+# D-Bus service details
+DBUS_SERVICE="org.desktopspec.ConfigManager"
+DBUS_PATH="/"
+UPDATE_METHOD="update"
+
+# Logging
+LOG_TAG="dconfig-trigger-handler"
+
+# Timestamp file for tracking changes
+TIMESTAMP_DIR="/var/lib/dde-dconfig-daemon"
+TIMESTAMP_FILE="$TIMESTAMP_DIR/last-trigger-time"
+
+log_info() {
+    logger -t "$LOG_TAG" "$1" 2>/dev/null || true
+    echo "$1"
+}
+
+log_error() {
+    logger -t "$LOG_TAG" -p daemon.err "$1" 2>/dev/null || true
+    echo "ERROR: $1" >&2
+}
+
+ensure_timestamp_dir() {
+    if [ ! -d "$TIMESTAMP_DIR" ]; then
+        log_info "Creating timestamp directory: $TIMESTAMP_DIR"
+        mkdir -p "$TIMESTAMP_DIR" || {
+            log_error "Failed to create timestamp directory: $TIMESTAMP_DIR"
+            return 1
+        }
+    fi
+}
+
+update_timestamp() {
+    ensure_timestamp_dir || return 1
+    touch "$TIMESTAMP_FILE" || {
+        log_error "Failed to update timestamp file: $TIMESTAMP_FILE"
+        return 1
+    }
+    log_info "Updated timestamp file: $TIMESTAMP_FILE"
+}
+
+is_config_file() {
+    local file="$1"
+    
+    if [ ! -f "$file" ] || [ ! -r "$file" ]; then
+        return 1
+    fi
+    
+    if [[ "$file" != *.json ]]; then
+        return 1
+    fi
+    
+    # Check if file is in one of the monitored directories
+    local is_in_monitored_dir=false
+    for config_dir in "${CONFIG_DIRS[@]}"; do
+        if [[ "$file" == "$config_dir"/* ]]; then
+            is_in_monitored_dir=true
+            break
+        fi
+    done
+    
+    if [ "$is_in_monitored_dir" = false ]; then
+        return 1
+    fi
+    
+    return 0
+}
+
+call_dbus_update() {
+    local config_path="$1"
+    
+    if dbus-send --system \
+        --dest="$DBUS_SERVICE" \
+        --type=method_call \
+        "$DBUS_PATH" \
+        "$DBUS_SERVICE.$UPDATE_METHOD" \
+        string:"$config_path" >/dev/null 2>&1; then
+        return 0
+    else
+        log_error "Failed to update configuration: $config_path"
+        return 1
+    fi
+}
+
+process_newer_files_in_directory() {
+    local dir="$1"
+    local processed_count=0
+    
+    if [ ! -d "$dir" ]; then
+        log_info "Directory does not exist: $dir"
+        return 0
+    fi
+    
+    if [ ! -f "$TIMESTAMP_FILE" ]; then
+        log_info "Timestamp file doesn't exist, creating it"
+        ensure_timestamp_dir
+        touch "$TIMESTAMP_FILE"
+    fi
+    
+    # Find JSON files newer than the timestamp file
+    while IFS= read -r -d '' config_file; do
+        if is_config_file "$config_file"; then
+            log_info "Found newer config file: $config_file"
+            if call_dbus_update "$config_file"; then
+                processed_count=$((processed_count + 1))
+            fi
+        fi
+    done < <(find "$dir" -name "*.json" -type f -cnewer "$TIMESTAMP_FILE" -print0 2>/dev/null)
+    
+    log_info "Processed $processed_count newer configuration files in $dir"
+    return 0
+}
+
+process_trigger_paths() {
+    local processed_count=0
+    
+    for trigger_path in "$@"; do
+        log_info "Processing trigger path: $trigger_path"
+        
+        if [ -f "$trigger_path" ]; then
+            if is_config_file "$trigger_path"; then
+                if call_dbus_update "$trigger_path"; then
+                    processed_count=$((processed_count + 1))
+                fi
+            else
+                log_info "Skipping non-config file: $trigger_path"
+            fi
+        elif [ -d "$trigger_path" ]; then
+            process_newer_files_in_directory "$trigger_path"
+        else
+            log_error "Trigger path does not exist: $trigger_path"
+        fi
+    done
+}
+
+main() {
+    if [ $# -gt 0 ]; then
+        process_trigger_paths "$@"
+        
+        # Update timestamp after processing trigger paths
+        update_timestamp
+    fi
+    
+    log_info "dconfig trigger handler completed"
+}
+
+main "$@"

--- a/debian/dde-dconfig-daemon.install
+++ b/debian/dde-dconfig-daemon.install
@@ -7,3 +7,4 @@ usr/share/dbus-1/interfaces/*
 usr/share/dbus-1/system-services/*
 usr/share/dde-dconfig/translations/*
 usr/lib/systemd/system/*
+usr/lib/dde-dconfig-daemon/*

--- a/debian/dde-dconfig-daemon.postinst
+++ b/debian/dde-dconfig-daemon.postinst
@@ -1,0 +1,41 @@
+#!/bin/sh
+set -e
+
+# Automatically added by dh_installsystemd/13.16
+if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-deconfigure" ] || [ "$1" = "abort-remove" ] ; then
+	if [ -d /run/systemd/system ]; then
+		systemctl --system daemon-reload >/dev/null || true
+		if [ -n "$2" ]; then
+			_dh_action=restart
+		else
+			_dh_action=start
+		fi
+		deb-systemd-invoke $_dh_action 'dde-dconfig-daemon.service' >/dev/null || true
+	fi
+	
+	TIMESTAMP_DIR="/var/lib/dde-dconfig-daemon"
+	TIMESTAMP_FILE="$TIMESTAMP_DIR/last-trigger-time"
+	
+	if [ ! -d "$TIMESTAMP_DIR" ]; then
+		mkdir -p "$TIMESTAMP_DIR"
+	fi
+	
+	# Always update timestamp file when package is configured
+	touch "$TIMESTAMP_FILE"
+fi
+# End automatically added section
+
+# Handle dconfig triggers
+if [ "$1" = "triggered" ]; then
+    # Skip the first argument (triggered)
+    shift
+    
+    # Execute trigger handler with all remaining arguments (trigger paths)
+    if [ -x /usr/lib/dde-dconfig-daemon/dconfig-trigger-handler ]; then
+        /usr/lib/dde-dconfig-daemon/dconfig-trigger-handler "$@"
+    else
+        echo "Warning: dconfig-trigger-handler not found or not executable"
+    fi
+fi
+
+exit 0

--- a/debian/dde-dconfig-daemon.triggers
+++ b/debian/dde-dconfig-daemon.triggers
@@ -1,0 +1,12 @@
+# Debian triggers for dde-dconfig-daemon
+# Monitor configuration file directories for changes
+
+# Monitor meta configuration files - use interest to get specific file paths
+interest /usr/share/dsg/configs
+interest /etc/dsg/configs
+
+# Monitor Linglong configuration files - use interest to get specific file paths
+interest /var/lib/linglong/entries/share/dsg/configs
+
+# Trigger name for processing configuration updates
+interest dconfig-trigger

--- a/debian/rules
+++ b/debian/rules
@@ -6,7 +6,7 @@ include /usr/share/dpkg/default.mk
 	dh $@ --parallel
 
 override_dh_auto_configure:
-	dh_auto_configure -- -DDVERSION=$(DEB_VERSION_UPSTREAM) -DDTK_VERSION=6
+	dh_auto_configure -- -DDVERSION=$(DEB_VERSION_UPSTREAM) -DDTK_VERSION=6 -DINSTALL_DEBIAN_TRIGGER=ON
 
 
 override_dh_auto_install:


### PR DESCRIPTION
1. Added dconfig-trigger-handler script to process configuration file changes via D-Bus
2. Implemented Debian trigger system to monitor config directories (/ usr/share/dsg/configs, /etc/dsg/configs, /var/lib/linglong entries)
3. Created postinst script to handle trigger activation and timestamp management
4. Added documentation explaining the trigger integration process and usage
5. Updated CMakeLists and install files to deploy the trigger handler
6. The changes enable automatic configuration updates when package installations modify config files

feat: 添加 Debian 触发器集成以支持配置自动更新

1. 新增 dconfig-trigger-handler 脚本通过 D-Bus 处理配置文件变更
2. 实现 Debian 触发器系统监控配置目录(/usr/share/dsg/configs, /etc/dsg/ configs, /var/lib/linglong 条目)
3. 创建 postinst 脚本处理触发器激活和时间戳管理
4. 添加文档说明触发器集成流程和使用方法
5. 更新 CMakeLists 和安装文件以部署触发器处理程序
6. 这些变更使得在包安装修改配置文件时能够自动更新配置

## Summary by Sourcery

Integrate Debian triggers to automate configuration updates on package installation by adding a D-Bus handler script and updating build and Debian packaging files.

New Features:
- Add dconfig-trigger-handler script to process configuration changes via D-Bus
- Integrate Debian trigger system with a .triggers file to monitor config directories
- Introduce postinst script to activate triggers and manage timestamp updates

Build:
- Update CMakeLists and install manifests to deploy the trigger handler script

Deployment:
- Add Debian packaging metadata (.triggers and .postinst) to support trigger integration