### PR TITLE
fix: simplify DBus service check and add cache path prefix

### DIFF
--- a/dconfig-center/common/valuehandler.cpp
+++ b/dconfig-center/common/valuehandler.cpp
@@ -304,7 +304,7 @@ int ValueHandler::currentUid()
 
 ConfigGetter* ValueHandler::createManager()
 {
-    if (DBusHandler::isServiceRegistered() || DBusHandler::isServiceActivatable()) {
+    if (DBusHandler::isServiceRegistered()) {
         auto tmp = new DBusHandler(this);
         if (tmp->createManager(appid, fileName, subpath)) {
             return tmp;

--- a/dconfig-center/dde-dconfig-daemon/dconfigresource.cpp
+++ b/dconfig-center/dde-dconfig-daemon/dconfigresource.cpp
@@ -126,6 +126,7 @@ bool DSGConfigResource::reparse(const QString &appid)
         return true;
 
     std::unique_ptr<DConfigFile> config(new DConfigFile(*file));
+    config->globalCache()->setCachePathPrefix(configPrefixPath() + "/global");
     auto newMeta = config->meta();
     if (!newMeta->load()) {
         qWarning() << QString("Reparse resource error for [%1].").arg(m_key);


### PR DESCRIPTION
1. Removed redundant `isServiceActivatable()` check in ValueHandler
since `isServiceRegistered()` is sufficient
2. Added explicit cache path prefix setting for global cache in
DSGConfigResource to ensure proper cache location
3. Changes improve code clarity and ensure consistent cache behavior

fix: 简化DBus服务检查并添加缓存路径前缀

1. 在ValueHandler中移除了多余的`isServiceActivatable()`检查，仅保留
`isServiceRegistered()`已足够
2. 在DSGConfigResource中为全局缓存添加了明确的路径前缀设置，确保缓存位置
正确
3. 这些改动提高了代码清晰度并保证了缓存行为的一致性

## Summary by Sourcery

Simplify the DBus service availability logic by eliminating an unnecessary check and ensure consistent cache behavior by explicitly prefixing the global cache path.

Enhancements:
- Remove redundant DBusHandler::isServiceActivatable() check and rely solely on isServiceRegistered()
- Add explicit cache path prefix for the global cache in DSGConfigResource to guarantee correct cache location