### PR TITLE
feat: add qvariantToCmd helper function

### DIFF
--- a/dconfig-center/common/helper.hpp
+++ b/dconfig-center/common/helper.hpp
@@ -227,6 +227,13 @@ static QVariant stringToQVariant(const QString &s)
     return s;
 }
 
+static QString qvariantToCmd(const QVariant &v)
+{
+    auto stringValue = qvariantToStringCompact(v);
+    auto jsonValue = QJsonValue::fromVariant(v);
+    return jsonValue.isBool() || jsonValue.isDouble() ? stringValue : QString("'%1'").arg(stringValue);
+}
+
 static QStringList translationDirs()
 {
     QStringList result;

--- a/dconfig-center/dde-dconfig-editor/mainwindow.cpp
+++ b/dconfig-center/dde-dconfig-editor/mainwindow.cpp
@@ -607,7 +607,7 @@ void Content::onCustomContextMenuRequested(QWidget *widget, const QString &appid
 {
     m_getter.reset(new ValueHandler(appid, resource, subpath));
     QScopedPointer<ConfigGetter> manager(m_getter->createManager());
-    const QString &value =  manager.get()->value(key).toString();
+    const QString &value = qvariantToCmd(manager.get()->value(key));
     const QString &description = manager.get()->description(key, m_language);
 
     QMenu *menu = new QMenu(widget);
@@ -645,8 +645,8 @@ void Content::onCustomContextMenuRequested(QWidget *widget, const QString &appid
         }
     });
     QClipboard *clip = QApplication::clipboard();
-    connect(copyAction, &QAction::triggered, this, [clip, key] {
-        clip->setText(key);
+    connect(copyAction, &QAction::triggered, this, [clip, value] {
+        clip->setText(value);
     });
     connect(copyCmdAction, &QAction::triggered, this, [clip, setCmd] {
         clip->setText(setCmd);


### PR DESCRIPTION
1. Added new helper function qvariantToCmd to properly format QVariant
values for command line usage
2. Modified context menu handling to use the new helper when copying
values
3. Ensures boolean and numeric values are copied without quotes while
strings remain quoted
4. Fixes issue where raw QVariant values could cause syntax errors in
command usage

feat: 添加 qvariantToCmd 辅助函数

1. 新增 qvariantToCmd 辅助函数，用于将 QVariant 值格式化为适合命令行使用
的格式
2. 修改上下文菜单处理逻辑，使用新辅助函数复制值
3. 确保布尔值和数值不加引号复制，而字符串保持引号包裹
4. 修复原始 QVariant 值可能导致命令语法错误的问题
