### PR TITLE
fix: remove redundant log messages in dconfig-trigger-handler

### DIFF
--- a/dconfig-center/dde-dconfig-daemon/scripts/dconfig-trigger-handler
+++ b/dconfig-center/dde-dconfig-daemon/scripts/dconfig-trigger-handler
@@ -113,7 +113,6 @@ process_newer_files_in_directory() {
     # Find JSON files newer than the timestamp file
     while IFS= read -r -d '' config_file; do
         if is_config_file "$config_file"; then
-            log_info "Found newer config file: $config_file"
             if call_dbus_update "$config_file"; then
                 processed_count=$((processed_count + 1))
             fi
@@ -128,7 +127,6 @@ process_trigger_paths() {
     local processed_count=0
     
     for trigger_path in "$@"; do
-        log_info "Processing trigger path: $trigger_path"
         
         if [ -f "$trigger_path" ]; then
             if is_config_file "$trigger_path"; then


### PR DESCRIPTION
1. Removed unnecessary debug log "Found newer config file" that was
cluttering logs
2. Removed redundant "Processing trigger path" log that provided little
value
3. These logs were deemed too verbose for production use
4. Maintains core functionality while cleaning up log output

fix: 移除 dconfig-trigger-handler 中的冗余日志消息

1. 移除了不必要的调试日志"Found newer config file"，这些日志使日志文件变
得杂乱
2. 移除了冗余的"Processing trigger path"日志，这些日志提供的价值有限
3. 这些日志被认为在生产环境中过于冗长
4. 在清理日志输出的同时保持了核心功能

## Summary by Sourcery

Enhancements:
- Remove redundant 'Found newer config file' and 'Processing trigger path' debug logs from the dconfig-trigger-handler to reduce log clutter.