### PR TITLE
chore: bump version to 1.0.33

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+dde-app-services (1.0.33) unstable; urgency=medium
+
+  * fix: remove redundant log messages in dconfig-trigger-handler
+  * feat: add qvariantToCmd helper function
+  * fix: simplify DBus service check and add cache path prefix
+
+ -- YeShanShan <yeshanshan@uniontech.com>  Fri, 27 Jun 2025 14:33:09 +0800
+
 dde-app-services (1.0.32) unstable; urgency=medium
 
   * feat: add Debian trigger integration for config updates (#111)


### PR DESCRIPTION
update changelog to 1.0.33

## Summary by Sourcery

Chores:
- Update Debian changelog version from 1.0.32 to 1.0.33