### PR TITLE
fix: missing QJsonValue header file

### DIFF
--- a/dconfig-center/common/helper.hpp
+++ b/dconfig-center/common/helper.hpp
@@ -11,6 +11,7 @@
 #include <QDirIterator>
 #include <QDBusArgument>
 #include <QJsonDocument>
+#include <QJsonValue>
 #include <DConfigFile>
 #include <dstandardpaths.h>
 #include <QCoreApplication>


### PR DESCRIPTION
cannot build on Archlinux

Log:
