### PR TITLE
chore: bump version to 1.0.34

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+dde-app-services (1.0.34) unstable; urgency=medium
+
+  * fix: add security hardening flags to build process
+  * fix: missing QJsonValue header file
+  * feat: implement config file reload mechanism
+
+ -- YeShanShan <yeshanshan@uniontech.com>  Thu, 03 Jul 2025 19:47:06 +0800
+
 dde-app-services (1.0.33) unstable; urgency=medium
 
   * fix: remove redundant log messages in dconfig-trigger-handler


### PR DESCRIPTION
update changelog to 1.0.34

## Summary by Sourcery

Chores:
- Update Debian changelog to reflect version 1.0.34 bump