### PR TITLE
feat: add version option to command line parser

### DIFF
--- a/dconfig-center/dde-dconfig/main.cpp
+++ b/dconfig-center/dde-dconfig/main.cpp
@@ -380,6 +380,7 @@ int main(int argc, char *argv[])
     QCommandLineParser parser;
     parser.setApplicationDescription(QCoreApplication::translate("main", "A console tool to get and set configuration items for DTK Config."));
     parser.addHelpOption();
+    parser.addVersionOption();
 
     QCommandLineOption uidOption("u", QCoreApplication::translate("main", "operate configure items of the user uid."), "uid", QString());
     parser.addOption(uidOption);

--- a/debian/rules
+++ b/debian/rules
@@ -12,7 +12,7 @@ export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed -Wl,-z,relro -Wl,-z,now -Wl,-z
 	dh $@ --parallel
 
 override_dh_auto_configure:
-	dh_auto_configure -- -DDVERSION=$(DEB_VERSION_UPSTREAM) -DDTK_VERSION=6
+	dh_auto_configure -- -DDTK_VERSION=6
 
 
 override_dh_auto_install:


### PR DESCRIPTION
1. Added version option to QCommandLineParser in main.cpp to display
version information
2. Removed DVERSION from debian/rules configuration as it's no longer
needed
3. Maintained DTK_VERSION setting in build configuration

The changes improve command line interface by adding standard --version
flag support while simplifying the build configuration by removing
redundant version setting.

feat: 为命令行解析器添加版本选项

1. 在 main.cpp 中为 QCommandLineParser 添加版本选项以显示版本信息
2. 从 debian/rules 配置中移除不再需要的 DVERSION 参数
3. 保留构建配置中的 DTK_VERSION 设置

这些改动通过添加标准的 --version 标志支持改进了命令行界面，同时通过移除
冗余的版本设置简化了构建配置。

## Summary by Sourcery

Add a standard --version flag to the CLI and simplify Debian packaging by removing the redundant DVERSION setting.

New Features:
- Add --version option to the command-line parser to display application version.

Build:
- Remove DVERSION from Debian packaging rules.
- Retain DTK_VERSION setting in build configuration.