### PR TITLE
fix: set DSG_DATA_DIRS for linglong compatibility

### DIFF
--- a/dconfig-center/dde-dconfig-editor/main.cpp
+++ b/dconfig-center/dde-dconfig-editor/main.cpp
@@ -13,6 +13,8 @@ DWIDGET_USE_NAMESPACE
 
 int main(int argc, char *argv[])
 {
+    setenv("DSG_DATA_DIRS", "/usr/share/dsg:/var/lib/linglong/entries/share/dsg", 0);
+
     DApplication a(argc, argv);
     a.setApplicationVersion(VERSION);
     a.setApplicationName("dde-dconfig-editor");

--- a/dconfig-center/dde-dconfig/main.cpp
+++ b/dconfig-center/dde-dconfig/main.cpp
@@ -372,6 +372,8 @@ int CommandManager::watchCommand()
 
 int main(int argc, char *argv[])
 {
+    setenv("DSG_DATA_DIRS", "/usr/share/dsg:/var/lib/linglong/entries/share/dsg", 0);
+
     QCoreApplication a(argc, argv);
     a.setApplicationVersion(VERSION);
 


### PR DESCRIPTION
Added DSG_DATA_DIRS environment variable setting in both dde-dconfig-
editor and dde-dconfig main functions
The variable is set to include both standard path (/usr/share/dsg) and
linglong container path (/var/lib/linglong/entries/share/dsg)
This ensures dconfig applications can access configuration files in both
standard and linglong environments
Maintains compatibility with dde-dconfig-daemon which already uses this
environment variable

fix: 为玲珑兼容性设置 DSG_DATA_DIRS 环境变量

在 dde-dconfig-editor 和 dde-dconfig 的主函数中添加了 DSG_DATA_DIRS 环境
变量设置
该变量包含标准路径 (/usr/share/dsg) 和玲珑容器路径 (/var/lib/linglong/
entries/share/dsg)
确保配置应用程序能够在标准环境和玲珑环境中访问配置文件
与已使用此环境变量的 dde-dconfig-daemon 保持兼容性
