### PR TITLE
fix: remove exit on postinst reload failure

### DIFF
--- a/debian/dde-dconfig-daemon.postinst
+++ b/debian/dde-dconfig-daemon.postinst
@@ -14,7 +14,6 @@ if [ "$1" = "triggered" ]; then
     else
         logger -t "dde-dconfig-daemon" -p daemon.err "Configuration trigger detected, reload failed" 2>/dev/null || true
         echo "ERROR: Configuration trigger detected, reload failed" >&2
-        exit 1
     fi
 fi
 


### PR DESCRIPTION
Removed the exit 1 command when configuration reload fails in postinst
script to comply with Debian post-installation script standards.
Post-installation scripts should not exit abnormally as it can break
package management operations. The error logging and message output
are preserved to ensure proper error reporting without interrupting the
package installation process.

fix: 移除 postinst 重载失败时的退出操作

移除 postinst 脚本中配置重载失败时的 exit 1 命令，以符合 Debian 安装后脚
本规范。安装后脚本不应异常退出，否则可能破坏包管理操作。保留错误日志和消
息输出功能，确保在不中断包安装过程的情况下进行正确的错误报告。

## Summary by Sourcery

Bug Fixes:
- Remove exit 1 call in postinst to comply with Debian post-installation script standards and prevent breaking package management operations