### PR TITLE
fix: handle termination signals properly

### DIFF
--- a/dconfig-center/dde-dconfig-daemon/main.cpp
+++ b/dconfig-center/dde-dconfig-daemon/main.cpp
@@ -24,10 +24,8 @@ int main(int argc, char *argv[])
     sigemptyset(&sa.sa_mask);
     sa.sa_flags = SA_RESETHAND;
 
-    sigaction(SIGSEGV, &sa, nullptr);
-    sigaction(SIGILL, &sa, nullptr);
-    sigaction(SIGABRT, &sa, nullptr);
-    sigaction(SIGFPE, &sa, nullptr);
+    sigaction(SIGTERM, &sa, nullptr);
+    sigaction(SIGINT, &sa, nullptr);
 
     QCoreApplication a(argc, argv);
     a.setOrganizationName("deepin");


### PR DESCRIPTION
Removed signal handlers for SIGSEGV, SIGILL, SIGABRT, and SIGFPE which
are typically fatal signals that should not be caught and handled by
applications. Added proper signal handling for SIGTERM and SIGINT which
are termination signals that applications should gracefully handle
for proper shutdown procedures. This ensures the daemon can respond to
system termination requests and user interrupt signals correctly.

fix: 正确处理终止信号

移除了对SIGSEGV、SIGILL、SIGABRT和SIGFPE的信号处理程序，这些通常是致命信
号，不应由应用程序捕获和处理。添加了对SIGTERM和SIGINT的适当信号处理，这
些是终止信号，应用程序应优雅处理以实现正确的关闭流程。这确保守护程序能够
正确响应系统终止请求和用户中断信号。
