### PR TITLE
fix: remove version option from command line parser

### DIFF
--- a/dconfig-center/dde-dconfig/main.cpp
+++ b/dconfig-center/dde-dconfig/main.cpp
@@ -382,7 +382,6 @@ int main(int argc, char *argv[])
     QCommandLineParser parser;
     parser.setApplicationDescription(QCoreApplication::translate("main", "A console tool to get and set configuration items for DTK Config."));
     parser.addHelpOption();
-    parser.addVersionOption();
 
     QCommandLineOption uidOption("u", QCoreApplication::translate("main", "operate configure items of the user uid."), "uid", QString());
     parser.addOption(uidOption);


### PR DESCRIPTION
The version option was removed from the QCommandLineParser as it was
unnecessary for this console tool. The application does not require a
version display option in its command line interface, simplifying the
user experience and reducing unnecessary functionality.

Influence:
1. Verify that the help option still works correctly
2. Test that all other command line options function as expected
3. Confirm the application starts without errors
4. Ensure no version-related commands are available in the CLI

fix: 从命令行解析器中移除版本选项

移除了 QCommandLineParser 中的版本选项，因为该控制台工具不需要此功能。应
用程序不需要在其命令行界面中显示版本选项，这简化了用户体验并减少了不必要
的功能。

Influence:
1. 验证帮助选项是否仍然正常工作
2. 测试所有其他命令行选项是否按预期运行
3. 确认应用程序启动时没有错误
4. 确保 CLI 中不再提供版本相关命令

## Summary by Sourcery

Enhancements:
- Remove the version option from the command-line parser to simplify the CLI and eliminate unnecessary functionality