### PR TITLE
chore: update changelog to 1.0.43

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-app-services (1.0.43) unstable; urgency=medium
+
+  * fix: fix override path matching in reload hotloading
+
+ -- zhangkun <zhangkun2@uniontech.com>  Wed, 25 Mar 2026 17:16:55 +0800
+
 dde-app-services (1.0.42) unstable; urgency=medium
 
   * fix: Fix dconfig input text not conforming to JSON standards


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 1.0.43

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 1.0.43
- 目标分支: master

## Summary by Sourcery

Chores:
- Bump Debian changelog entry to version 1.0.43 targeting the master branch.