### PR TITLE
fix: fix config reload abort on file update failure and uppercase path matching

### DIFF
--- a/dconfig-center/dde-dconfig-daemon/dconfig_global.h
+++ b/dconfig-center/dde-dconfig-daemon/dconfig_global.h
@@ -96,7 +96,9 @@ inline ConfigureId getMetaConfigureId(const QString &path)
     ConfigureId info;
     // /usr/share/dsg/configs/[$appid]/[$subpath]/$resource.json
     // Use negative lookahead (?!overrides/) to exclude override paths which should be handled by getOverrideConfigureId
-    static QRegularExpression usrReg(R"(/configs/(?!overrides/)(?<appid>([a-z0-9\s\-_\@\-\^!#$%&.]+\/)?)(?<subpath>([a-z0-9\s\-_\@\-\^!#$%&.]+\/)*)(?<resource>[a-z0-9\s\-_\@\-\^!#$%&.]+).json$)");
+    static QRegularExpression usrReg(
+        R"(/configs/(?!overrides/)(?<appid>(?>[a-zA-Z0-9\s_@^!#$%&.\-]+)\/)?(?<subpath>(?:(?>[a-zA-Z0-9\s_@^!#$%&.\-]+)\/)*)(?<resource>[a-zA-Z0-9\s_@^!#$%&.\-]+)\.json$)"
+    );
 
     QRegularExpressionMatch match;
     match = usrReg.match(path);
@@ -114,10 +116,14 @@ inline ConfigureId getOverrideConfigureId(const QString &path)
 {
     ConfigureId info;
     // /usr/share/dsg/configs/overrides/[$appid]/$resource/[$subpath]/$override_id.json
-    static QRegularExpression usrReg(R"(/configs/overrides/(?<appid>([a-z0-9\s\-_\@\-\^!#$%&.]+\/)?)(?<resource>[a-z0-9\s\-_\@\-\^!#$%&.]+)/(?<subpath>([a-z0-9\s\-_\@\-\^!#$%&.]+\/)*)(?<configurationid>[a-z0-9\s\-_\@\-\^!#$%&.]+).json$)");
+    static QRegularExpression usrReg(
+        R"(/configs/overrides/(?<appid>(?>[a-zA-Z0-9\s_@^!#$%&.\-]+)\/)?(?<resource>(?>[a-zA-Z0-9\s_@^!#$%&.\-]+))/(?<subpath>(?:(?>[a-zA-Z0-9\s_@^!#$%&.\-]+)\/)*)(?<configurationid>[a-zA-Z0-9\s_@^!#$%&.\-]+)\.json$)"
+    );
 
     // /etc/dsg/configs/overrides/[$appid]/$resource/[$subpath]/$override_id.json
-    static QRegularExpression etcReg(R"(^/etc/dsg/configs/overrides/(?<appid>([a-z0-9\s\-_\@\-\^!#$%&.]+\/)?)(?<resource>[a-z0-9\s\-_\@\-\^!#$%&.]+)/(?<subpath>([a-z0-9\s\-_\@\-\^!#$%&.]+\/)*)(?<configurationid>[a-z0-9\s\-_\@\-\^!#$%&.]+).json$)");
+    static QRegularExpression etcReg(
+        R"(^/etc/dsg/configs/overrides/(?<appid>(?>[a-zA-Z0-9\s_@^!#$%&.\-]+)\/)?(?<resource>(?>[a-zA-Z0-9\s_@^!#$%&.\-]+))/(?<subpath>(?:(?>[a-zA-Z0-9\s_@^!#$%&.\-]+)\/)*)(?<configurationid>[a-zA-Z0-9\s_@^!#$%&.\-]+)\.json$)"
+    );
 
     QRegularExpressionMatch match;
     match = usrReg.match(path);

--- a/dconfig-center/dde-dconfig-daemon/dconfigserver.cpp
+++ b/dconfig-center/dde-dconfig-daemon/dconfigserver.cpp
@@ -435,7 +435,7 @@ bool DSGConfigServer::isConfigurePath(const QString &path, const QString &appId)
  当描述文件被修改或override目录新增、移除、修改文件时，需要重新解析对应的文件内容，
  提供刷新服务，由配置工具调用来运行时刷新提供的文件访问信息。
  */
-void DSGConfigServer::update(const QString &path)
+std::optional<QString> DSGConfigServer::updateInternal(const QString &path)
 {
     qCInfo(cfLog()) << "Update resource:" << path;
 
@@ -445,14 +445,8 @@ void DSGConfigServer::update(const QString &path)
            qPrintable(configureInfo.subpath),
            qPrintable(configureInfo.resource));
     if (configureInfo.isInValid()) {
-        QString errorMsg = QString("It's illegal resource [%1].").arg(path);
-        if (calledFromDBus()) {
-            sendErrorReply(QDBusError::Failed, errorMsg);
-        }
-        qWarning() << errorMsg;
-        return;
+        return QString("It's illegal resource [%1].").arg(path);
     }
-
 
     const GenericResourceKey resourceKey = getGenericResourceKey(configureInfo.resource, configureInfo.subpath);
     if (auto resource = resourceObject(resourceKey)) {
@@ -461,11 +455,19 @@ void DSGConfigServer::update(const QString &path)
                qPrintable(configureInfo.appid));
         const auto &innerAppid = outerAppidToInner(configureInfo.appid);
         if (!resource->reparse(innerAppid)) {
-            QString errorMsg = QString("Update the resource path[%1] error.").arg(path);
-            if (calledFromDBus()) {
-                sendErrorReply(QDBusError::Failed, errorMsg);
-            }
-            qWarning() << qPrintable(errorMsg);
+            return QString("Update the resource path[%1] error.").arg(path);
+        }
+    }
+    return std::nullopt;
+}
+
+void DSGConfigServer::update(const QString &path)
+{
+    const auto errorMsg = updateInternal(path);
+    if (errorMsg) {
+        qWarning() << *errorMsg;
+        if (calledFromDBus()) {
+            sendErrorReply(QDBusError::Failed, *errorMsg);
         }
     }
 }
@@ -557,12 +559,23 @@ void DSGConfigServer::reload()
 
     changedFiles.removeDuplicates();
 
-    // Process changed files
-    for (const auto &file : std::as_const(changedFiles)) {
-        update(file);
+    if (changedFiles.isEmpty()) {
+        qCInfo(cfLog()) << "Reload completed, no files changed";
+        return;
     }
 
-    qCInfo(cfLog()) << "Reload completed, processed" << changedFiles.size() << "files";
+    // Process changed files
+    int failedCount = 0;
+    for (const auto &file : std::as_const(changedFiles)) {
+        const auto errorMsg = updateInternal(file);
+        if (errorMsg) {
+            qCWarning(cfLog()) << "Reload failed to update file:" << file << ", reason:" << *errorMsg;
+            ++failedCount;
+        }
+    }
+
+    qCInfo(cfLog()) << "Reload completed, processed" << changedFiles.size() << "files,"
+                    << failedCount << "failed";
 }
 
 // Get all configuration file signatures

--- a/dconfig-center/dde-dconfig-daemon/dconfigserver.h
+++ b/dconfig-center/dde-dconfig-daemon/dconfigserver.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "dconfig_global.h"
+#include <optional>
 #include <QObject>
 #include <QDBusObjectPath>
 #include <QDBusContext>
@@ -83,6 +84,9 @@ private:
     ConfigureId getConfigureIdByPath(const QString &path);
 
     bool isConfigurePath(const QString &path, const QString& appId) const;
+
+    std::optional<QString> updateInternal(const QString &path);
+
     // Reload interface related structures and methods
     struct FileSignature {
         qint64 size;


### PR DESCRIPTION
1. Change reload() to continue processing remaining files when one
update fails, instead of aborting early
2. Add updateInternal() method that returns error string without sending
DBus error, allowing reload to handle failures gracefully
3. Fix regular expression patterns to support uppercase letters in
configuration paths, as file systems may use mixed case
4. Track failure count during reload to report accurate processing
results

Log: Fixed reload aborting on file update failure and added uppercase
path support

Influence:
1. Test reload with multiple files where one update fails, verify
remaining files still process
2. Test configuration paths with uppercase letters to ensure proper
matching
3. Verify DBus error response still works correctly for single file
updates
4. Check reload completes without hanging on consecutive failures

fix: 修复配置重载在文件更新失败时提前终止以及大写路径匹配错误的问题

1. 修改 reload() 函数，当某个文件更新失败时继续处理剩余文件，而不是提前
终止
2. 添加 updateInternal() 方法，返回错误字符串而不发送 DBus 错误，使
reload 能优雅处理失败
3. 修复正则表达式模式，支持配置文件路径中的大写字母，因为文件系统可能使
用混合大小写
4. 在重载过程中跟踪失败计数，以报告准确的处理结果

Log: 修复重载在文件更新失败时提前终止的问题，并增加大写路径支持

Influence:
1. 测试多文件重载，其中一个文件更新失败，验证其他文件仍能正常处理
2. 测试包含大写字母的配置文件路径，确保正确匹配
3. 验证单个文件更新时 DBus 错误响应仍正常工作
4. 检查连续失败时重载不会卡住

PMS: BUG-360197
