### PR TITLE
chore: update changelog to 1.0.44

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-app-services (1.0.44) unstable; urgency=medium
+
+  * fix: support uppercase filenames and prevent reload abort on partial
+    failure
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 14 May 2026 20:03:22 +0800
+
 dde-app-services (1.0.43) unstable; urgency=medium
 
   * fix: fix override path matching in reload hotloading


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 1.0.44

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 1.0.44
- 目标分支: master

## Summary by Sourcery

Chores:
- Bump debian/changelog entry to version 1.0.44 targeting master.