### PR TITLE
[暂不合并]fix(dde-dconfig-daemon): disable THP before service startup

### DIFF
--- a/dconfig-center/dde-dconfig-daemon/services/dde-dconfig-daemon.service
+++ b/dconfig-center/dde-dconfig-daemon/services/dde-dconfig-daemon.service
@@ -9,6 +9,7 @@ After=dbus.socket
 Type=dbus
 User=deepin-daemon
 BusName=org.desktopspec.ConfigManager
+ExecStartPre=-/usr/libexec/dde-thp-disable
 ExecStart=/usr/bin/dde-dconfig-daemon
 Environment=DSG_DATA_DIRS=/usr/share/dsg:/var/lib/linglong/entries/share/dsg
 


### PR DESCRIPTION
1. Added ExecStartPre to disable Transparent Huge Pages before dconfig daemon starts
2. Uses dde-thp-disable script to prevent THP-related memory issues

Log: Disable THP before dde-dconfig-daemon startup

fix(dde-dconfig-daemon): 服务启动前禁用透明大页

1. 新增 ExecStartPre 在 dconfig daemon 启动前禁用透明大页
2. 通过 dde-thp-disable 脚本避免 THP 导致的内存问题

Log: 在 dde-dconfig-daemon 启动前禁用透明大页
PMS: TASK-390043