### PR TITLE
feat(dconfig-editor): add copy field name in context menu

### DIFF
--- a/dconfig-center/dde-dconfig-editor/mainwindow.cpp
+++ b/dconfig-center/dde-dconfig-editor/mainwindow.cpp
@@ -621,7 +621,8 @@ void Content::onCustomContextMenuRequested(QWidget *widget, const QString &appid
     QMenu *menu = new QMenu(widget);
 
     QAction *exportAction = menu->addAction(tr("export"));
-    QAction *copyAction = menu->addAction(tr("copy value"));
+    QAction *copyFieldAction = menu->addAction(tr("copy field name"));
+    QAction *copyValueAction = menu->addAction(tr("copy value"));
     QAction *copyCmdAction = menu->addAction(tr("convert to cmd"));
     QAction *resetCmdAction = menu->addAction(tr("reset value"));
 
@@ -653,7 +654,10 @@ void Content::onCustomContextMenuRequested(QWidget *widget, const QString &appid
         }
     });
     QClipboard *clip = QApplication::clipboard();
-    connect(copyAction, &QAction::triggered, this, [clip, value] {
+    connect(copyFieldAction, &QAction::triggered, this, [clip, key] {
+        clip->setText(key);
+    });
+    connect(copyValueAction, &QAction::triggered, this, [clip, value] {
         clip->setText(value);
     });
     connect(copyCmdAction, &QAction::triggered, this, [clip, setCmd] {

--- a/dconfig-center/dde-dconfig-editor/translates/dde-dconfig-editor_zh_CN.ts
+++ b/dconfig-center/dde-dconfig-editor/translates/dde-dconfig-editor_zh_CN.ts
@@ -14,6 +14,11 @@
         <translation>复制值</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="624"/>
+        <source>copy field name</source>
+        <translation>复制字段名</translation>
+    </message>
+    <message>
         <location filename="../mainwindow.cpp" line="593"/>
         <source>convert to cmd</source>
         <translation>复制命令</translation>


### PR DESCRIPTION
## Summary

Add "copy field name" right-click menu option to copy the field key to clipboard in dde-dconfig-editor.

## Changes
- Added `copy field name` action to the right-click context menu on the rightmost list
- Copies the field key name to clipboard on trigger
- Renamed `copyAction` to `copyValueAction` for clarity
- Added Chinese translation for the new menu item